### PR TITLE
Stabilized test suite

### DIFF
--- a/lib/handler/summoner/performance.js
+++ b/lib/handler/summoner/performance.js
@@ -101,6 +101,9 @@ module.exports.get = function(req, res) {
             ward = items.shift();
           }
 
+          // Sometimes, the ward is not detected as a ward, so we need to ensure we never send more than 6 items
+          items = items.slice(0, 6);
+
           var matchUrl = "http://matchhistory.";
           matchUrl += req.query.region.toLowerCase();
           matchUrl += ".leagueoflegends.com/en/#match-details/";

--- a/test/mocks/mocks/get__summoner_counter_should_fail_for_unknown_summoner.json
+++ b/test/mocks/mocks/get__summoner_counter_should_fail_for_unknown_summoner.json
@@ -1,7 +1,52 @@
 [
   {
+    "scope": "https://ddragon.leagueoflegends.com:443",
+    "method": "GET",
+    "path": "/realms/euw.json",
+    "body": "",
+    "status": 200,
+    "response": {
+      "n": {
+        "item": "6.22.1",
+        "rune": "6.22.1",
+        "mastery": "6.22.1",
+        "summoner": "6.22.1",
+        "champion": "6.22.1",
+        "profileicon": "6.22.1",
+        "map": "6.22.1",
+        "language": "6.22.1"
+      },
+      "v": "6.22.1",
+      "l": "en_GB",
+      "cdn": "http://ddragon.leagueoflegends.com/cdn",
+      "dd": "6.22.1",
+      "lg": "6.22.1",
+      "css": "6.22.1",
+      "profileiconmax": 28,
+      "store": null
+    },
+    "headers": {
+      "content-type": "text/json; charset=UTF-8",
+      "content-length": "307",
+      "connection": "close",
+      "accept-ranges": "bytes",
+      "access-control-allow-origin": "*",
+      "age": "366",
+      "cache-control": "must-revalidate, no-cache, private",
+      "date": "Sun, 13 Nov 2016 14:55:04 GMT",
+      "etag": "\"b629bafa47432ff8c0555937d69dd18e\"",
+      "server": "Apache/2.2.29 (Amazon)",
+      "via": "1.1 varnish, 1.1 901427b25164532ae97382d031da28b7.cloudfront.net (CloudFront)",
+      "x-content-digest": "enc240ea78e07b1e8b664f1ad5ff5349862f5dab90",
+      "x-powered-by": "PHP/5.3.29",
+      "x-varnish": "2602711191 2602611891",
+      "x-cache": "Miss from cloudfront",
+      "x-amz-cf-id": "WDR1EBAoG0P6s4kzkg_dCIyGzz_djNBX9_XqEVQ3dF1uQUX8QeDbcg=="
+    }
+  },
+  {
     "scope": "https://euw.api.pvp.net:443",
-    "method": "get",
+    "method": "GET",
     "path": "/api/lol/euw/v1.4/summoner/by-name/404summ",
     "body": "",
     "status": 404,
@@ -13,9 +58,6666 @@
     },
     "headers": {
       "content-type": "application/json;charset=utf-8",
-      "x-rate-limit-count": "16:10,10859:600",
-      "transfer-encoding": "chunked",
+      "x-rate-limit-count": "259:10,16522:600",
+      "content-length": "66",
       "connection": "Close"
+    }
+  },
+  {
+    "scope": "https://ddragon.leagueoflegends.com:443",
+    "method": "GET",
+    "path": "/cdn/6.22.1/data/en_US/champion.json",
+    "body": "",
+    "status": 200,
+    "response": {
+      "type": "champion",
+      "format": "standAloneComplex",
+      "version": "6.22.1",
+      "data": {
+        "Aatrox": {
+          "version": "6.22.1",
+          "id": "Aatrox",
+          "key": "266",
+          "name": "Aatrox",
+          "title": "the Darkin Blade",
+          "blurb": "Aatrox is a legendary warrior, one of only five that remain of an ancient race known as the Darkin. He wields his massive blade with grace and poise, slicing through legions in a style that is hypnotic to behold. With each foe felled, Aatrox's ...",
+          "info": {
+            "attack": 8,
+            "defense": 4,
+            "magic": 3,
+            "difficulty": 4
+          },
+          "image": {
+            "full": "Aatrox.png",
+            "sprite": "champion0.png",
+            "group": "champion",
+            "x": 0,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Fighter",
+            "Tank"
+          ],
+          "partype": "BloodWell",
+          "stats": {
+            "hp": 537.8,
+            "hpperlevel": 85,
+            "mp": 105.6,
+            "mpperlevel": 45,
+            "movespeed": 345,
+            "armor": 24.384,
+            "armorperlevel": 3.8,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 150,
+            "hpregen": 6.59,
+            "hpregenperlevel": 0.5,
+            "mpregen": 0,
+            "mpregenperlevel": 0,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 60.376,
+            "attackdamageperlevel": 3.2,
+            "attackspeedoffset": -0.04,
+            "attackspeedperlevel": 3
+          }
+        },
+        "Ahri": {
+          "version": "6.22.1",
+          "id": "Ahri",
+          "key": "103",
+          "name": "Ahri",
+          "title": "the Nine-Tailed Fox",
+          "blurb": "Unlike other foxes that roamed the woods of southern Ionia, Ahri had always felt a strange connection to the magical world around her; a connection that was somehow incomplete. Deep inside, she felt the skin she had been born into was an ill fit for ...",
+          "info": {
+            "attack": 3,
+            "defense": 4,
+            "magic": 8,
+            "difficulty": 5
+          },
+          "image": {
+            "full": "Ahri.png",
+            "sprite": "champion0.png",
+            "group": "champion",
+            "x": 48,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Mage",
+            "Assassin"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 514.4,
+            "hpperlevel": 80,
+            "mp": 334,
+            "mpperlevel": 50,
+            "movespeed": 330,
+            "armor": 20.88,
+            "armorperlevel": 3.5,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 550,
+            "hpregen": 6.505,
+            "hpregenperlevel": 0.6,
+            "mpregen": 6,
+            "mpregenperlevel": 0.8,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 53.04,
+            "attackdamageperlevel": 3,
+            "attackspeedoffset": -0.065,
+            "attackspeedperlevel": 2
+          }
+        },
+        "Akali": {
+          "version": "6.22.1",
+          "id": "Akali",
+          "key": "84",
+          "name": "Akali",
+          "title": "the Fist of Shadow",
+          "blurb": "There exists an ancient order originating in the Ionian Isles dedicated to the preservation of balance. Order, chaos, light, darkness -- all things must exist in perfect harmony for such is the way of the universe. This order is known as the Kinkou ...",
+          "info": {
+            "attack": 5,
+            "defense": 3,
+            "magic": 8,
+            "difficulty": 7
+          },
+          "image": {
+            "full": "Akali.png",
+            "sprite": "champion0.png",
+            "group": "champion",
+            "x": 96,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Assassin"
+          ],
+          "partype": "Energy",
+          "stats": {
+            "hp": 587.8,
+            "hpperlevel": 85,
+            "mp": 200,
+            "mpperlevel": 0,
+            "movespeed": 350,
+            "armor": 26.38,
+            "armorperlevel": 3.5,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 8.34,
+            "hpregenperlevel": 0.65,
+            "mpregen": 50,
+            "mpregenperlevel": 0,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 58.376,
+            "attackdamageperlevel": 3.2,
+            "attackspeedoffset": -0.1,
+            "attackspeedperlevel": 3.1
+          }
+        },
+        "Alistar": {
+          "version": "6.22.1",
+          "id": "Alistar",
+          "key": "12",
+          "name": "Alistar",
+          "title": "the Minotaur",
+          "blurb": "As the mightiest warrior to ever emerge from the Minotaur tribes of the Great Barrier, Alistar defended his tribe from Valoran's many dangers; that is, until the coming of the Noxian army. Alistar was lured from his village by the machinations of ...",
+          "info": {
+            "attack": 6,
+            "defense": 9,
+            "magic": 5,
+            "difficulty": 7
+          },
+          "image": {
+            "full": "Alistar.png",
+            "sprite": "champion0.png",
+            "group": "champion",
+            "x": 144,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Tank",
+            "Support"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 613.36,
+            "hpperlevel": 106,
+            "mp": 278.84,
+            "mpperlevel": 38,
+            "movespeed": 330,
+            "armor": 24.38,
+            "armorperlevel": 3.5,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 8.675,
+            "hpregenperlevel": 0.85,
+            "mpregen": 8.5,
+            "mpregenperlevel": 0.8,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 61.1116,
+            "attackdamageperlevel": 3.62,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 2.125
+          }
+        },
+        "Amumu": {
+          "version": "6.22.1",
+          "id": "Amumu",
+          "key": "32",
+          "name": "Amumu",
+          "title": "the Sad Mummy",
+          "blurb": "''Solitude can be lonelier than death.''<br><br>A lonely and melancholy soul from ancient Shurima, Amumu roams the world in search of a friend. Cursed by an ancient spell, he is doomed to remain alone forever, as his touch is death and his affection ...",
+          "info": {
+            "attack": 2,
+            "defense": 6,
+            "magic": 8,
+            "difficulty": 3
+          },
+          "image": {
+            "full": "Amumu.png",
+            "sprite": "champion0.png",
+            "group": "champion",
+            "x": 192,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Tank",
+            "Mage"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 613.12,
+            "hpperlevel": 84,
+            "mp": 287.2,
+            "mpperlevel": 40,
+            "movespeed": 335,
+            "armor": 23.544,
+            "armorperlevel": 3.8,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 8.875,
+            "hpregenperlevel": 0.85,
+            "mpregen": 7.38,
+            "mpregenperlevel": 0.525,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 53.384,
+            "attackdamageperlevel": 3.8,
+            "attackspeedoffset": -0.02,
+            "attackspeedperlevel": 2.18
+          }
+        },
+        "Anivia": {
+          "version": "6.22.1",
+          "id": "Anivia",
+          "key": "34",
+          "name": "Anivia",
+          "title": "the Cryophoenix",
+          "blurb": "Anivia is a being of the coldest winter, a mystical embodiment of ice magic, and an ancient protector of the Freljord. She commands all the power and fury of the land itself, calling the snow and bitter wind to defend her home from those who would ...",
+          "info": {
+            "attack": 1,
+            "defense": 4,
+            "magic": 10,
+            "difficulty": 10
+          },
+          "image": {
+            "full": "Anivia.png",
+            "sprite": "champion0.png",
+            "group": "champion",
+            "x": 240,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Mage",
+            "Support"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 467.6,
+            "hpperlevel": 70,
+            "mp": 396.04,
+            "mpperlevel": 50,
+            "movespeed": 325,
+            "armor": 21.22,
+            "armorperlevel": 4,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 600,
+            "hpregen": 5.57,
+            "hpregenperlevel": 0.55,
+            "mpregen": 6,
+            "mpregenperlevel": 0.8,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 51.376,
+            "attackdamageperlevel": 3.2,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 1.68
+          }
+        },
+        "Annie": {
+          "version": "6.22.1",
+          "id": "Annie",
+          "key": "1",
+          "name": "Annie",
+          "title": "the Dark Child",
+          "blurb": "There have always been those within Noxus who did not agree with the evils perpetrated by the Noxian High Command. The High Command had just put down a coup attempt from the self-proclaimed Crown Prince Raschallion, and a crackdown on any form of ...",
+          "info": {
+            "attack": 2,
+            "defense": 3,
+            "magic": 10,
+            "difficulty": 6
+          },
+          "image": {
+            "full": "Annie.png",
+            "sprite": "champion0.png",
+            "group": "champion",
+            "x": 288,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Mage"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 511.68,
+            "hpperlevel": 76,
+            "mp": 334,
+            "mpperlevel": 50,
+            "movespeed": 335,
+            "armor": 19.22,
+            "armorperlevel": 4,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 575,
+            "hpregen": 5.42,
+            "hpregenperlevel": 0.55,
+            "mpregen": 6,
+            "mpregenperlevel": 0.8,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 50.41,
+            "attackdamageperlevel": 2.625,
+            "attackspeedoffset": 0.08,
+            "attackspeedperlevel": 1.36
+          }
+        },
+        "Ashe": {
+          "version": "6.22.1",
+          "id": "Ashe",
+          "key": "22",
+          "name": "Ashe",
+          "title": "the Frost Archer",
+          "blurb": "With each arrow she fires from her ancient ice-enchanted bow, Ashe proves she is a master archer. She chooses each target carefully, waits for the right moment, and then strikes with power and precision. It is with this same vision and focus that she ...",
+          "info": {
+            "attack": 7,
+            "defense": 3,
+            "magic": 2,
+            "difficulty": 4
+          },
+          "image": {
+            "full": "Ashe.png",
+            "sprite": "champion0.png",
+            "group": "champion",
+            "x": 336,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Marksman",
+            "Support"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 527.72,
+            "hpperlevel": 79,
+            "mp": 280,
+            "mpperlevel": 32,
+            "movespeed": 325,
+            "armor": 21.212,
+            "armorperlevel": 3.4,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 600,
+            "hpregen": 5.42,
+            "hpregenperlevel": 0.55,
+            "mpregen": 6.97,
+            "mpregenperlevel": 0.4,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 56.508,
+            "attackdamageperlevel": 2.26,
+            "attackspeedoffset": -0.05,
+            "attackspeedperlevel": 3.33
+          }
+        },
+        "AurelionSol": {
+          "version": "6.22.1",
+          "id": "AurelionSol",
+          "key": "136",
+          "name": "Aurelion Sol",
+          "title": "The Star Forger",
+          "blurb": "Aurelion Sol once graced the vast emptiness of the cosmos with celestial wonders of his own devising. Now, he is forced to wield his awesome power at the behest of a space-faring empire that tricked him into servitude. Desiring a return to his ...",
+          "info": {
+            "attack": 2,
+            "defense": 3,
+            "magic": 8,
+            "difficulty": 7
+          },
+          "image": {
+            "full": "AurelionSol.png",
+            "sprite": "champion0.png",
+            "group": "champion",
+            "x": 384,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Mage",
+            "Fighter"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 550,
+            "hpperlevel": 80,
+            "mp": 350,
+            "mpperlevel": 50,
+            "movespeed": 325,
+            "armor": 19,
+            "armorperlevel": 3.6,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 550,
+            "hpregen": 6.5,
+            "hpregenperlevel": 0.6,
+            "mpregen": 6,
+            "mpregenperlevel": 0.8,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 57,
+            "attackdamageperlevel": 3.2,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 1.36
+          }
+        },
+        "Azir": {
+          "version": "6.22.1",
+          "id": "Azir",
+          "key": "268",
+          "name": "Azir",
+          "title": "the Emperor of the Sands",
+          "blurb": "''Shurima was once the glory of Runeterra. I will make it so again.''<br><br>Azir was a mortal emperor of Shurima in a far distant age, a proud man who stood at the cusp of immortality. His hubris saw him betrayed and murdered at the moment of his ...",
+          "info": {
+            "attack": 6,
+            "defense": 3,
+            "magic": 8,
+            "difficulty": 9
+          },
+          "image": {
+            "full": "Azir.png",
+            "sprite": "champion0.png",
+            "group": "champion",
+            "x": 432,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Mage",
+            "Marksman"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 524.4,
+            "hpperlevel": 80,
+            "mp": 350.56,
+            "mpperlevel": 42,
+            "movespeed": 325,
+            "armor": 19.04,
+            "armorperlevel": 3,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 525,
+            "hpregen": 6.92,
+            "hpregenperlevel": 0.55,
+            "mpregen": 6,
+            "mpregenperlevel": 0.8,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 52,
+            "attackdamageperlevel": 2.8,
+            "attackspeedoffset": -0.02,
+            "attackspeedperlevel": 1.5
+          }
+        },
+        "Bard": {
+          "version": "6.22.1",
+          "id": "Bard",
+          "key": "432",
+          "name": "Bard",
+          "title": "the Wandering Caretaker",
+          "blurb": "Bard travels through realms beyond the imagination of mortal beings. Some of Valoran's greatest scholars have spent their lives trying to understand the mysteries he embodies. This enigmatic spirit has been given many names throughout the history of ...",
+          "info": {
+            "attack": 4,
+            "defense": 4,
+            "magic": 5,
+            "difficulty": 9
+          },
+          "image": {
+            "full": "Bard.png",
+            "sprite": "champion0.png",
+            "group": "champion",
+            "x": 0,
+            "y": 48,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Support",
+            "Mage"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 535,
+            "hpperlevel": 89,
+            "mp": 350,
+            "mpperlevel": 50,
+            "movespeed": 330,
+            "armor": 25,
+            "armorperlevel": 4,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 500,
+            "hpregen": 5.4,
+            "hpregenperlevel": 0.55,
+            "mpregen": 6,
+            "mpregenperlevel": 0.45,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 52,
+            "attackdamageperlevel": 3,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 2
+          }
+        },
+        "Blitzcrank": {
+          "version": "6.22.1",
+          "id": "Blitzcrank",
+          "key": "53",
+          "name": "Blitzcrank",
+          "title": "the Great Steam Golem",
+          "blurb": "Zaun is a place where both magic and science have gone awry, and the unchecked nature of experimentation has taken its toll. However, Zaun's lenient restrictions allow their researchers and inventors the leeway to push the bounds of science at an ...",
+          "info": {
+            "attack": 4,
+            "defense": 8,
+            "magic": 5,
+            "difficulty": 4
+          },
+          "image": {
+            "full": "Blitzcrank.png",
+            "sprite": "champion0.png",
+            "group": "champion",
+            "x": 48,
+            "y": 48,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Tank",
+            "Fighter"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 582.6,
+            "hpperlevel": 95,
+            "mp": 267.2,
+            "mpperlevel": 40,
+            "movespeed": 325,
+            "armor": 24.38,
+            "armorperlevel": 4,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 8.51,
+            "hpregenperlevel": 0.75,
+            "mpregen": 8.5,
+            "mpregenperlevel": 0.8,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 61.54,
+            "attackdamageperlevel": 3.5,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 1.13
+          }
+        },
+        "Brand": {
+          "version": "6.22.1",
+          "id": "Brand",
+          "key": "63",
+          "name": "Brand",
+          "title": "the Burning Vengeance",
+          "blurb": "In a faraway place known as Lokfar there was a seafaring marauder called Kegan Rodhe. As was his people's way, Kegan sailed far and wide with his fellows, stealing treasures from those unlucky enough to catch their attention. To some, he was a ...",
+          "info": {
+            "attack": 2,
+            "defense": 2,
+            "magic": 9,
+            "difficulty": 4
+          },
+          "image": {
+            "full": "Brand.png",
+            "sprite": "champion0.png",
+            "group": "champion",
+            "x": 96,
+            "y": 48,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Mage"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 507.68,
+            "hpperlevel": 76,
+            "mp": 375.6,
+            "mpperlevel": 42,
+            "movespeed": 340,
+            "armor": 21.88,
+            "armorperlevel": 3.5,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 550,
+            "hpregen": 5.42,
+            "hpregenperlevel": 0.55,
+            "mpregen": 8.005,
+            "mpregenperlevel": 0.6,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 57.04,
+            "attackdamageperlevel": 3,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 1.36
+          }
+        },
+        "Braum": {
+          "version": "6.22.1",
+          "id": "Braum",
+          "key": "201",
+          "name": "Braum",
+          "title": "the Heart of the Freljord",
+          "blurb": "''Would you like a bedtime story?''<br><br>''Grandma, I'm too old for that.''<br><br>''You're never too old to be told a story.''<br><br>The girl reluctantly crawls into bed and waits, knowing she won't win this battle. A bitter wind howls outside, ...",
+          "info": {
+            "attack": 3,
+            "defense": 9,
+            "magic": 4,
+            "difficulty": 3
+          },
+          "image": {
+            "full": "Braum.png",
+            "sprite": "champion0.png",
+            "group": "champion",
+            "x": 144,
+            "y": 48,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Support",
+            "Tank"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 576.16,
+            "hpperlevel": 87,
+            "mp": 310.6,
+            "mpperlevel": 45,
+            "movespeed": 335,
+            "armor": 26.72,
+            "armorperlevel": 4.5,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 8.18,
+            "hpregenperlevel": 1,
+            "mpregen": 6,
+            "mpregenperlevel": 0.8,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 55.376,
+            "attackdamageperlevel": 3.2,
+            "attackspeedoffset": -0.03,
+            "attackspeedperlevel": 3.5
+          }
+        },
+        "Caitlyn": {
+          "version": "6.22.1",
+          "id": "Caitlyn",
+          "key": "51",
+          "name": "Caitlyn",
+          "title": "the Sheriff of Piltover",
+          "blurb": "''Go ahead, run. I'll give you a five minute head start.''<br><br>One of the reasons Piltover is known as the City of Progress is because it has an extraordinarily low crime rate. This hasn't always been the case; brigands and thieves of all sorts ...",
+          "info": {
+            "attack": 8,
+            "defense": 2,
+            "magic": 2,
+            "difficulty": 6
+          },
+          "image": {
+            "full": "Caitlyn.png",
+            "sprite": "champion0.png",
+            "group": "champion",
+            "x": 192,
+            "y": 48,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Marksman"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 524.4,
+            "hpperlevel": 80,
+            "mp": 313.7,
+            "mpperlevel": 35,
+            "movespeed": 325,
+            "armor": 22.88,
+            "armorperlevel": 3.5,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 650,
+            "hpregen": 5.67,
+            "hpregenperlevel": 0.55,
+            "mpregen": 7.4,
+            "mpregenperlevel": 0.55,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 53.66,
+            "attackdamageperlevel": 2.18,
+            "attackspeedoffset": 0.1,
+            "attackspeedperlevel": 4
+          }
+        },
+        "Cassiopeia": {
+          "version": "6.22.1",
+          "id": "Cassiopeia",
+          "key": "69",
+          "name": "Cassiopeia",
+          "title": "the Serpent's Embrace",
+          "blurb": "Cassiopeia is a terrifying creature - half woman, half snake - whose slightest glance brings death. The youngest daughter of one of Noxus' most influential families, she was once a beautiful and cunning temptress capable of manipulating the hardest ...",
+          "info": {
+            "attack": 2,
+            "defense": 3,
+            "magic": 9,
+            "difficulty": 10
+          },
+          "image": {
+            "full": "Cassiopeia.png",
+            "sprite": "champion0.png",
+            "group": "champion",
+            "x": 240,
+            "y": 48,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Mage"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 525,
+            "hpperlevel": 75,
+            "mp": 375,
+            "mpperlevel": 60,
+            "movespeed": 328,
+            "armor": 25,
+            "armorperlevel": 3.5,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 550,
+            "hpregen": 5.5,
+            "hpregenperlevel": 0.5,
+            "mpregen": 6,
+            "mpregenperlevel": 0.8,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 53,
+            "attackdamageperlevel": 3,
+            "attackspeedoffset": -0.034,
+            "attackspeedperlevel": 1.5
+          }
+        },
+        "Chogath": {
+          "version": "6.22.1",
+          "id": "Chogath",
+          "key": "31",
+          "name": "Cho'Gath",
+          "title": "the Terror of the Void",
+          "blurb": "There is a place between dimensions, between worlds. To some it is known as the Outside, to others it is the Unknown. To those that truly know, however, it is called the Void. Despite its name, the Void is not an empty place, but rather the home of ...",
+          "info": {
+            "attack": 3,
+            "defense": 7,
+            "magic": 7,
+            "difficulty": 5
+          },
+          "image": {
+            "full": "Chogath.png",
+            "sprite": "champion0.png",
+            "group": "champion",
+            "x": 288,
+            "y": 48,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Tank",
+            "Mage"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 574.4,
+            "hpperlevel": 80,
+            "mp": 272.2,
+            "mpperlevel": 40,
+            "movespeed": 345,
+            "armor": 28.88,
+            "armorperlevel": 3.5,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 8.925,
+            "hpregenperlevel": 0.85,
+            "mpregen": 7.205,
+            "mpregenperlevel": 0.45,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 61.156,
+            "attackdamageperlevel": 4.2,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 1.44
+          }
+        },
+        "Corki": {
+          "version": "6.22.1",
+          "id": "Corki",
+          "key": "42",
+          "name": "Corki",
+          "title": "the Daring Bombardier",
+          "blurb": "When Heimerdinger and his yordle colleagues migrated to Piltover, they embraced science as a way of life, and they immediately made several groundbreaking contributions to the techmaturgical community. What yordles lack in stature, they make up for ...",
+          "info": {
+            "attack": 8,
+            "defense": 3,
+            "magic": 6,
+            "difficulty": 6
+          },
+          "image": {
+            "full": "Corki.png",
+            "sprite": "champion0.png",
+            "group": "champion",
+            "x": 336,
+            "y": 48,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Marksman"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 512.76,
+            "hpperlevel": 82,
+            "mp": 350.16,
+            "mpperlevel": 34,
+            "movespeed": 325,
+            "armor": 23.38,
+            "armorperlevel": 3.5,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 550,
+            "hpregen": 5.42,
+            "hpregenperlevel": 0.55,
+            "mpregen": 7.42,
+            "mpregenperlevel": 0.55,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 56,
+            "attackdamageperlevel": 3.5,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 2.3
+          }
+        },
+        "Darius": {
+          "version": "6.22.1",
+          "id": "Darius",
+          "key": "122",
+          "name": "Darius",
+          "title": "the Hand of Noxus",
+          "blurb": "There is no greater symbol of Noxian might than Darius, the nation's most feared and battle-hardened warrior. Orphaned at a young age, Darius had to fight to keep himself and his younger brother alive. By the time he joined the military, he had ...",
+          "info": {
+            "attack": 9,
+            "defense": 5,
+            "magic": 1,
+            "difficulty": 2
+          },
+          "image": {
+            "full": "Darius.png",
+            "sprite": "champion0.png",
+            "group": "champion",
+            "x": 384,
+            "y": 48,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Fighter",
+            "Tank"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 582.24,
+            "hpperlevel": 100,
+            "mp": 263,
+            "mpperlevel": 37.5,
+            "movespeed": 340,
+            "armor": 30,
+            "armorperlevel": 4,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 175,
+            "hpregen": 9.845,
+            "hpregenperlevel": 0.95,
+            "mpregen": 6.585,
+            "mpregenperlevel": 0.35,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 56,
+            "attackdamageperlevel": 5,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 1
+          }
+        },
+        "Diana": {
+          "version": "6.22.1",
+          "id": "Diana",
+          "key": "131",
+          "name": "Diana",
+          "title": "Scorn of the Moon",
+          "blurb": "''I am the light coursing in the soul of the moon.''<br><br>Bearing her crescent moonblade, Diana fights as a warrior of the Lunari, a faith all but quashed in the lands around Mount Targon. Clad in shimmering armor the color of winter snow at night, ...",
+          "info": {
+            "attack": 7,
+            "defense": 6,
+            "magic": 8,
+            "difficulty": 4
+          },
+          "image": {
+            "full": "Diana.png",
+            "sprite": "champion0.png",
+            "group": "champion",
+            "x": 432,
+            "y": 48,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Fighter",
+            "Mage"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 589.2,
+            "hpperlevel": 90,
+            "mp": 297.2,
+            "mpperlevel": 40,
+            "movespeed": 345,
+            "armor": 26.048,
+            "armorperlevel": 3.6,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 150,
+            "hpregen": 7.425,
+            "hpregenperlevel": 0.85,
+            "mpregen": 6,
+            "mpregenperlevel": 0.8,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 53.04,
+            "attackdamageperlevel": 3,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 2.25
+          }
+        },
+        "Draven": {
+          "version": "6.22.1",
+          "id": "Draven",
+          "key": "119",
+          "name": "Draven",
+          "title": "the Glorious Executioner",
+          "blurb": "Unlike his brother Darius, victory in battle was never enough for Draven. He craved recognition, acclaim, and glory. He first sought greatness in the Noxian military, but his flair for the dramatic went severely underappreciated. Thirsting for a ...",
+          "info": {
+            "attack": 9,
+            "defense": 3,
+            "magic": 1,
+            "difficulty": 8
+          },
+          "image": {
+            "full": "Draven.png",
+            "sprite": "champion0.png",
+            "group": "champion",
+            "x": 0,
+            "y": 96,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Marksman"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 557.76,
+            "hpperlevel": 82,
+            "mp": 360.56,
+            "mpperlevel": 39,
+            "movespeed": 330,
+            "armor": 25.544,
+            "armorperlevel": 3.3,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 550,
+            "hpregen": 6.175,
+            "hpregenperlevel": 0.7,
+            "mpregen": 8.04,
+            "mpregenperlevel": 0.65,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 55.8,
+            "attackdamageperlevel": 2.91,
+            "attackspeedoffset": -0.08,
+            "attackspeedperlevel": 2.7
+          }
+        },
+        "DrMundo": {
+          "version": "6.22.1",
+          "id": "DrMundo",
+          "key": "36",
+          "name": "Dr. Mundo",
+          "title": "the Madman of Zaun",
+          "blurb": "''Beware the Madman of Zaun. In his eyes, you are already dead''<br><br>It is said that the man now known as Dr. Mundo was born without any sort of conscience. Instead, he had an unquenchable desire to inflict pain through experimentation. By the time ...",
+          "info": {
+            "attack": 5,
+            "defense": 7,
+            "magic": 6,
+            "difficulty": 5
+          },
+          "image": {
+            "full": "DrMundo.png",
+            "sprite": "champion0.png",
+            "group": "champion",
+            "x": 48,
+            "y": 96,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Fighter",
+            "Tank"
+          ],
+          "partype": "None",
+          "stats": {
+            "hp": 582.52,
+            "hpperlevel": 89,
+            "mp": 0,
+            "mpperlevel": 0,
+            "movespeed": 345,
+            "armor": 26.88,
+            "armorperlevel": 3.5,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 7.76,
+            "hpregenperlevel": 0.75,
+            "mpregen": 0,
+            "mpregenperlevel": 0,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 61.27,
+            "attackdamageperlevel": 3,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 2.8
+          }
+        },
+        "Ekko": {
+          "version": "6.22.1",
+          "id": "Ekko",
+          "key": "245",
+          "name": "Ekko",
+          "title": "the Boy Who Shattered Time",
+          "blurb": "A prodigy from the rough streets of Zaun, Ekko manipulates time to spin any situation to his advantage. Using his own invention, the Zero-Drive, he explores the branching possibilities of reality. As well as experimenting with multi-dimensional ...",
+          "info": {
+            "attack": 5,
+            "defense": 3,
+            "magic": 7,
+            "difficulty": 8
+          },
+          "image": {
+            "full": "Ekko.png",
+            "sprite": "champion0.png",
+            "group": "champion",
+            "x": 96,
+            "y": 96,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Assassin",
+            "Fighter"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 580,
+            "hpperlevel": 80,
+            "mp": 280,
+            "mpperlevel": 50,
+            "movespeed": 340,
+            "armor": 27,
+            "armorperlevel": 3,
+            "spellblock": 32,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 9,
+            "hpregenperlevel": 0.9,
+            "mpregen": 7,
+            "mpregenperlevel": 0.8,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 55,
+            "attackdamageperlevel": 3,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 3.3
+          }
+        },
+        "Elise": {
+          "version": "6.22.1",
+          "id": "Elise",
+          "key": "60",
+          "name": "Elise",
+          "title": "the Spider Queen",
+          "blurb": "''Beauty is power too, and can strike swifter than any sword.''<br><br>Elise is a deadly predator who dwells in a shuttered, lightless palace, deep in the Immortal Bastion of Noxus. Once she was mortal, the mistress of a once-powerful house, but the ...",
+          "info": {
+            "attack": 6,
+            "defense": 5,
+            "magic": 7,
+            "difficulty": 9
+          },
+          "image": {
+            "full": "Elise.png",
+            "sprite": "champion0.png",
+            "group": "champion",
+            "x": 144,
+            "y": 96,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Mage",
+            "Fighter"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 529.4,
+            "hpperlevel": 80,
+            "mp": 324,
+            "mpperlevel": 50,
+            "movespeed": 325,
+            "armor": 22.128,
+            "armorperlevel": 3.35,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 550,
+            "hpregen": 5.705,
+            "hpregenperlevel": 0.6,
+            "mpregen": 6,
+            "mpregenperlevel": 0.8,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 50.54,
+            "attackdamageperlevel": 3,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 1.75
+          }
+        },
+        "Evelynn": {
+          "version": "6.22.1",
+          "id": "Evelynn",
+          "key": "28",
+          "name": "Evelynn",
+          "title": "the Widowmaker",
+          "blurb": "Swift and lethal, Evelynn is one of the most deadly - and expensive - assassins in all of Runeterra. Able to merge with the shadows at will, she patiently stalks her prey, waiting for the right moment to strike. While Evelynn is clearly not entirely ...",
+          "info": {
+            "attack": 4,
+            "defense": 2,
+            "magic": 7,
+            "difficulty": 10
+          },
+          "image": {
+            "full": "Evelynn.png",
+            "sprite": "champion0.png",
+            "group": "champion",
+            "x": 192,
+            "y": 96,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Assassin",
+            "Mage"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 531.2,
+            "hpperlevel": 90,
+            "mp": 315.6,
+            "mpperlevel": 42,
+            "movespeed": 340,
+            "armor": 26.5,
+            "armorperlevel": 3.8,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 9.82,
+            "hpregenperlevel": 0.55,
+            "mpregen": 8.105,
+            "mpregenperlevel": 0.6,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 53.88,
+            "attackdamageperlevel": 3.5,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 3.6
+          }
+        },
+        "Ezreal": {
+          "version": "6.22.1",
+          "id": "Ezreal",
+          "key": "81",
+          "name": "Ezreal",
+          "title": "the Prodigal Explorer",
+          "blurb": "The intrepid young adventurer Ezreal has explored some of the most remote and abandoned locations on Runeterra. During an expedition to the buried ruins of ancient Shurima, he recovered an amulet of incredible mystical power. Likely constructed to be ...",
+          "info": {
+            "attack": 7,
+            "defense": 2,
+            "magic": 6,
+            "difficulty": 7
+          },
+          "image": {
+            "full": "Ezreal.png",
+            "sprite": "champion0.png",
+            "group": "champion",
+            "x": 240,
+            "y": 96,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Marksman",
+            "Mage"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 484.4,
+            "hpperlevel": 80,
+            "mp": 360.6,
+            "mpperlevel": 42,
+            "movespeed": 325,
+            "armor": 21.88,
+            "armorperlevel": 3.5,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 550,
+            "hpregen": 6.42,
+            "hpregenperlevel": 0.55,
+            "mpregen": 8.09,
+            "mpregenperlevel": 0.65,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 55.66,
+            "attackdamageperlevel": 2.41,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 2.8
+          }
+        },
+        "FiddleSticks": {
+          "version": "6.22.1",
+          "id": "FiddleSticks",
+          "key": "9",
+          "name": "Fiddlesticks",
+          "title": "the Harbinger of Doom",
+          "blurb": "For nearly twenty years, Fiddlesticks has stood alone in the easternmost summoning chamber of the Institute of War. Only the burning emerald light of his unearthly gaze pierces the musty darkness of his dust-covered home. It is here that the Harbinger ...",
+          "info": {
+            "attack": 2,
+            "defense": 3,
+            "magic": 9,
+            "difficulty": 9
+          },
+          "image": {
+            "full": "FiddleSticks.png",
+            "sprite": "champion0.png",
+            "group": "champion",
+            "x": 288,
+            "y": 96,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Mage",
+            "Support"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 524.4,
+            "hpperlevel": 80,
+            "mp": 400.12,
+            "mpperlevel": 56,
+            "movespeed": 335,
+            "armor": 20.88,
+            "armorperlevel": 3.5,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 480,
+            "hpregen": 5.605,
+            "hpregenperlevel": 0.6,
+            "mpregen": 6,
+            "mpregenperlevel": 0.8,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 48.36,
+            "attackdamageperlevel": 2.625,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 2.11
+          }
+        },
+        "Fiora": {
+          "version": "6.22.1",
+          "id": "Fiora",
+          "key": "114",
+          "name": "Fiora",
+          "title": "the Grand Duelist",
+          "blurb": "''I have come to kill you for the sake of honor. And though you possess none, still you die.''<br>The most feared duelist in all Valoran, Fiora is as renowned for her brusque manner and cunning mind as she is for the speed of her bluesteel rapier. ...",
+          "info": {
+            "attack": 10,
+            "defense": 4,
+            "magic": 2,
+            "difficulty": 3
+          },
+          "image": {
+            "full": "Fiora.png",
+            "sprite": "champion0.png",
+            "group": "champion",
+            "x": 336,
+            "y": 96,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Fighter",
+            "Assassin"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 550,
+            "hpperlevel": 85,
+            "mp": 300,
+            "mpperlevel": 40,
+            "movespeed": 345,
+            "armor": 24,
+            "armorperlevel": 3.5,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 150,
+            "hpregen": 8.25,
+            "hpregenperlevel": 0.55,
+            "mpregen": 8,
+            "mpregenperlevel": 0.7,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 60,
+            "attackdamageperlevel": 3.3,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 3.2
+          }
+        },
+        "Fizz": {
+          "version": "6.22.1",
+          "id": "Fizz",
+          "key": "105",
+          "name": "Fizz",
+          "title": "the Tidal Trickster",
+          "blurb": "Centuries ago, an ancient water-dwelling race built a hidden city beneath a mountain in the sea. Though these creatures had their enemies, the city was an impenetrable fortress, and, in the safety it provided, they grew complacent. Fizz, however, ...",
+          "info": {
+            "attack": 6,
+            "defense": 4,
+            "magic": 7,
+            "difficulty": 6
+          },
+          "image": {
+            "full": "Fizz.png",
+            "sprite": "champion0.png",
+            "group": "champion",
+            "x": 384,
+            "y": 96,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Assassin",
+            "Fighter"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 558.48,
+            "hpperlevel": 86,
+            "mp": 317.2,
+            "mpperlevel": 37,
+            "movespeed": 335,
+            "armor": 22.412,
+            "armorperlevel": 3.4,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 175,
+            "hpregen": 8.175,
+            "hpregenperlevel": 0.7,
+            "mpregen": 6,
+            "mpregenperlevel": 0.8,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 58.04,
+            "attackdamageperlevel": 3,
+            "attackspeedoffset": -0.05,
+            "attackspeedperlevel": 3.1
+          }
+        },
+        "Galio": {
+          "version": "6.22.1",
+          "id": "Galio",
+          "key": "3",
+          "name": "Galio",
+          "title": "the Sentinel's Sorrow",
+          "blurb": "''There is no such thing as redemption. Only penance.''<br><br>Long before the regulation of magic, mages experimented with the creation of artificial life. Now forbidden, instilling golems with reason was once not so uncommon a practice amongst the ...",
+          "info": {
+            "attack": 3,
+            "defense": 7,
+            "magic": 6,
+            "difficulty": 3
+          },
+          "image": {
+            "full": "Galio.png",
+            "sprite": "champion0.png",
+            "group": "champion",
+            "x": 432,
+            "y": 96,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Tank",
+            "Mage"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 577.8,
+            "hpperlevel": 85,
+            "mp": 369,
+            "mpperlevel": 47,
+            "movespeed": 335,
+            "armor": 26.88,
+            "armorperlevel": 3.5,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 8.71,
+            "hpregenperlevel": 0.75,
+            "mpregen": 6,
+            "mpregenperlevel": 0.8,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 61.97,
+            "attackdamageperlevel": 3.375,
+            "attackspeedoffset": -0.02,
+            "attackspeedperlevel": 1.2
+          }
+        },
+        "Gangplank": {
+          "version": "6.22.1",
+          "id": "Gangplank",
+          "key": "41",
+          "name": "Gangplank",
+          "title": "the Saltwater Scourge",
+          "blurb": "''I was cutting throats and sinking Noxian war galleys when you were still pissing your britches, boy. You don't want to take me on.''<br><br>As unpredictable as he is brutal, the dethroned reaver king known as Gangplank is feared far and wide. Where ...",
+          "info": {
+            "attack": 7,
+            "defense": 6,
+            "magic": 4,
+            "difficulty": 9
+          },
+          "image": {
+            "full": "Gangplank.png",
+            "sprite": "champion1.png",
+            "group": "champion",
+            "x": 0,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Fighter"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 540,
+            "hpperlevel": 82,
+            "mp": 282,
+            "mpperlevel": 40,
+            "movespeed": 345,
+            "armor": 26,
+            "armorperlevel": 3,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 6,
+            "hpregenperlevel": 0.6,
+            "mpregen": 7.5,
+            "mpregenperlevel": 0.7,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 56,
+            "attackdamageperlevel": 3,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 3.2
+          }
+        },
+        "Garen": {
+          "version": "6.22.1",
+          "id": "Garen",
+          "key": "86",
+          "name": "Garen",
+          "title": "The Might of Demacia",
+          "blurb": "Throughout Valoran, the resolve of Demacia's military is alternately celebrated or despised, but always respected. Their ''zero tolerance'' moral code is strictly upheld by civilians and soldiers alike. In combat, this means Demacian troops may not ...",
+          "info": {
+            "attack": 7,
+            "defense": 7,
+            "magic": 1,
+            "difficulty": 5
+          },
+          "image": {
+            "full": "Garen.png",
+            "sprite": "champion1.png",
+            "group": "champion",
+            "x": 48,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Fighter",
+            "Tank"
+          ],
+          "partype": "None",
+          "stats": {
+            "hp": 616.28,
+            "hpperlevel": 84.25,
+            "mp": 0,
+            "mpperlevel": 0,
+            "movespeed": 340,
+            "armor": 27.536,
+            "armorperlevel": 3,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 175,
+            "hpregen": 7.84,
+            "hpregenperlevel": 0.5,
+            "mpregen": 0,
+            "mpregenperlevel": 0,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 57.88,
+            "attackdamageperlevel": 4.5,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 2.9
+          }
+        },
+        "Gnar": {
+          "version": "6.22.1",
+          "id": "Gnar",
+          "key": "150",
+          "name": "Gnar",
+          "title": "the Missing Link",
+          "blurb": "The jungle does not forgive blindness. Every broken branch tells a story.<br><br>I've hunted every creature this jungle has to offer. I was certain there were no challenges left here, but now there is something new. Each track is the size of a ...",
+          "info": {
+            "attack": 6,
+            "defense": 5,
+            "magic": 5,
+            "difficulty": 8
+          },
+          "image": {
+            "full": "Gnar.png",
+            "sprite": "champion1.png",
+            "group": "champion",
+            "x": 96,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Fighter",
+            "Tank"
+          ],
+          "partype": "Gnarfury",
+          "stats": {
+            "hp": 540,
+            "hpperlevel": 65,
+            "mp": 100,
+            "mpperlevel": 0,
+            "movespeed": 325,
+            "armor": 23,
+            "armorperlevel": 2.5,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 175,
+            "hpregen": 2.5,
+            "hpregenperlevel": 0.5,
+            "mpregen": 0,
+            "mpregenperlevel": 0,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 51,
+            "attackdamageperlevel": 3,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 6
+          }
+        },
+        "Gragas": {
+          "version": "6.22.1",
+          "id": "Gragas",
+          "key": "79",
+          "name": "Gragas",
+          "title": "the Rabble Rouser",
+          "blurb": "The only thing more important to Gragas than fighting is drinking. His unquenchable thirst for stronger ale has led him in search of the most potent and unconventional ingredients to toss in his still. Impulsive and unpredictable, this rowdy carouser ...",
+          "info": {
+            "attack": 4,
+            "defense": 7,
+            "magic": 6,
+            "difficulty": 5
+          },
+          "image": {
+            "full": "Gragas.png",
+            "sprite": "champion1.png",
+            "group": "champion",
+            "x": 144,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Fighter",
+            "Mage"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 583.52,
+            "hpperlevel": 89,
+            "mp": 400,
+            "mpperlevel": 47,
+            "movespeed": 330,
+            "armor": 26.048,
+            "armorperlevel": 3.6,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 5.5,
+            "hpregenperlevel": 0.5,
+            "mpregen": 6,
+            "mpregenperlevel": 0.8,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 61.38,
+            "attackdamageperlevel": 3.5,
+            "attackspeedoffset": -0.04,
+            "attackspeedperlevel": 2.05
+          }
+        },
+        "Graves": {
+          "version": "6.22.1",
+          "id": "Graves",
+          "key": "104",
+          "name": "Graves",
+          "title": "the Outlaw",
+          "blurb": "Malcolm Graves is a wanted man in every realm, city and empire he has visited. Tough, strong-willed, and above all, relentless, through his life of crime he has amassed (then invariably lost) a small fortune.",
+          "info": {
+            "attack": 8,
+            "defense": 5,
+            "magic": 3,
+            "difficulty": 3
+          },
+          "image": {
+            "full": "Graves.png",
+            "sprite": "champion1.png",
+            "group": "champion",
+            "x": 192,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Marksman"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 551.12,
+            "hpperlevel": 84,
+            "mp": 322.2,
+            "mpperlevel": 40,
+            "movespeed": 340,
+            "armor": 24.376,
+            "armorperlevel": 3.4,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 425,
+            "hpregen": 6.675,
+            "hpregenperlevel": 0.7,
+            "mpregen": 7.9,
+            "mpregenperlevel": 0.7,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 60.83,
+            "attackdamageperlevel": 2.41,
+            "attackspeedoffset": 0.3,
+            "attackspeedperlevel": 2.6
+          }
+        },
+        "Hecarim": {
+          "version": "6.22.1",
+          "id": "Hecarim",
+          "key": "120",
+          "name": "Hecarim",
+          "title": "the Shadow of War",
+          "blurb": "''Break their ranks and ride them down without mercy. Crush the living and feast on their terror.''<br><br>Hecarim is an armored colossus who charges from the Shadow Isles at the head of a deathly host of spectral horsemen to hunt the living. A ...",
+          "info": {
+            "attack": 8,
+            "defense": 6,
+            "magic": 4,
+            "difficulty": 6
+          },
+          "image": {
+            "full": "Hecarim.png",
+            "sprite": "champion1.png",
+            "group": "champion",
+            "x": 240,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Fighter",
+            "Tank"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 580,
+            "hpperlevel": 90,
+            "mp": 277.2,
+            "mpperlevel": 40,
+            "movespeed": 345,
+            "armor": 26.72,
+            "armorperlevel": 4,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 175,
+            "hpregen": 7,
+            "hpregenperlevel": 0.75,
+            "mpregen": 6.5,
+            "mpregenperlevel": 0.6,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 58,
+            "attackdamageperlevel": 3.2,
+            "attackspeedoffset": -0.0672,
+            "attackspeedperlevel": 2.5
+          }
+        },
+        "Heimerdinger": {
+          "version": "6.22.1",
+          "id": "Heimerdinger",
+          "key": "74",
+          "name": "Heimerdinger",
+          "title": "the Revered Inventor",
+          "blurb": "From the Journal of Professor Cecil B. Heimerdinger<br><br>10.14<br><br>09:15<br><br>Current meteorological conditions in Bandle City seem optimal. Atmospheric pressure is ideal for today's experiments!<br><br>Running a fifth trial for my ...",
+          "info": {
+            "attack": 2,
+            "defense": 6,
+            "magic": 8,
+            "difficulty": 8
+          },
+          "image": {
+            "full": "Heimerdinger.png",
+            "sprite": "champion1.png",
+            "group": "champion",
+            "x": 288,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Mage",
+            "Support"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 476,
+            "hpperlevel": 75,
+            "mp": 307.2,
+            "mpperlevel": 40,
+            "movespeed": 340,
+            "armor": 19.04,
+            "armorperlevel": 3,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 550,
+            "hpregen": 11.005,
+            "hpregenperlevel": 1.75,
+            "mpregen": 6,
+            "mpregenperlevel": 0.8,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 55.536,
+            "attackdamageperlevel": 2.7,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 1.36
+          }
+        },
+        "Illaoi": {
+          "version": "6.22.1",
+          "id": "Illaoi",
+          "key": "420",
+          "name": "Illaoi",
+          "title": "the Kraken Priestess",
+          "blurb": "''I'm not big on sermons. Broken bones teach better lessons.''<br>Illaoi's powerful physique is dwarfed only by her indomitable faith. As the prophet of the Great Kraken, she uses a huge, golden idol to rip her foes' spirits from their bodies and ...",
+          "info": {
+            "attack": 8,
+            "defense": 6,
+            "magic": 3,
+            "difficulty": 4
+          },
+          "image": {
+            "full": "Illaoi.png",
+            "sprite": "champion1.png",
+            "group": "champion",
+            "x": 336,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Fighter",
+            "Tank"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 585.6,
+            "hpperlevel": 95,
+            "mp": 300,
+            "mpperlevel": 40,
+            "movespeed": 340,
+            "armor": 26,
+            "armorperlevel": 3.8,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 9.5,
+            "hpregenperlevel": 0.8,
+            "mpregen": 7.5,
+            "mpregenperlevel": 0.75,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 60,
+            "attackdamageperlevel": 5,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 2.5
+          }
+        },
+        "Irelia": {
+          "version": "6.22.1",
+          "id": "Irelia",
+          "key": "39",
+          "name": "Irelia",
+          "title": "the Will of the Blades",
+          "blurb": "''The sword flourishes, as though painting with blood.''<br><br>The Ionians have developed some of the most breathtaking and deadly martial arts in all of Runeterra - just one manifestation of their pursuit of enlightenment. The most remarkable blade ...",
+          "info": {
+            "attack": 7,
+            "defense": 4,
+            "magic": 5,
+            "difficulty": 5
+          },
+          "image": {
+            "full": "Irelia.png",
+            "sprite": "champion1.png",
+            "group": "champion",
+            "x": 384,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Fighter",
+            "Assassin"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 607.2,
+            "hpperlevel": 90,
+            "mp": 338.8,
+            "mpperlevel": 32,
+            "movespeed": 345,
+            "armor": 25.3,
+            "armorperlevel": 3.75,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 8.59,
+            "hpregenperlevel": 0.65,
+            "mpregen": 8.1,
+            "mpregenperlevel": 0.65,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 61.544,
+            "attackdamageperlevel": 3.3,
+            "attackspeedoffset": -0.06,
+            "attackspeedperlevel": 3.2
+          }
+        },
+        "Ivern": {
+          "version": "6.22.1",
+          "id": "Ivern",
+          "key": "427",
+          "name": "Ivern",
+          "title": "the Green Father",
+          "blurb": "Ivern Bramblefoot, known to many as the Green Father, is a peculiar half man, half tree who roams Runeterra's forests, cultivating life everywhere he goes. He knows the secrets of the natural world, and holds deep friendships with all things that grow,...",
+          "info": {
+            "attack": 3,
+            "defense": 5,
+            "magic": 7,
+            "difficulty": 7
+          },
+          "image": {
+            "full": "Ivern.png",
+            "sprite": "champion4.png",
+            "group": "champion",
+            "x": 96,
+            "y": 48,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Support",
+            "Mage"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 580,
+            "hpperlevel": 90,
+            "mp": 450,
+            "mpperlevel": 60,
+            "movespeed": 330,
+            "armor": 22,
+            "armorperlevel": 3.5,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 6.9,
+            "hpregenperlevel": 0.85,
+            "mpregen": 6,
+            "mpregenperlevel": 0.75,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 50,
+            "attackdamageperlevel": 3,
+            "attackspeedoffset": -0.03,
+            "attackspeedperlevel": 3.4
+          }
+        },
+        "Janna": {
+          "version": "6.22.1",
+          "id": "Janna",
+          "key": "40",
+          "name": "Janna",
+          "title": "the Storm's Fury",
+          "blurb": "There are those sorcerers who give themselves over to the primal powers of nature, forgoing the learned practice of magic. Such a sorceress is Janna, who first learned magic as an orphan growing up amidst the chaos that is the city-state of Zaun. ...",
+          "info": {
+            "attack": 3,
+            "defense": 5,
+            "magic": 7,
+            "difficulty": 7
+          },
+          "image": {
+            "full": "Janna.png",
+            "sprite": "champion1.png",
+            "group": "champion",
+            "x": 432,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Support",
+            "Mage"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 487.04,
+            "hpperlevel": 78,
+            "mp": 409.52,
+            "mpperlevel": 64,
+            "movespeed": 335,
+            "armor": 19.384,
+            "armorperlevel": 3.8,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 475,
+            "hpregen": 5.42,
+            "hpregenperlevel": 0.55,
+            "mpregen": 11.5,
+            "mpregenperlevel": 0.4,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 51.956,
+            "attackdamageperlevel": 2.95,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 2.61
+          }
+        },
+        "JarvanIV": {
+          "version": "6.22.1",
+          "id": "JarvanIV",
+          "key": "59",
+          "name": "Jarvan IV",
+          "title": "the Exemplar of Demacia",
+          "blurb": "''There is only one truth, and you will find it at the point of my lance.''<br><br>As the royal family of Demacia for centuries, members of the Lightshield line have spent their lives waging war against any who opposed Demacian ethics. It is said that ...",
+          "info": {
+            "attack": 6,
+            "defense": 8,
+            "magic": 3,
+            "difficulty": 5
+          },
+          "image": {
+            "full": "JarvanIV.png",
+            "sprite": "champion1.png",
+            "group": "champion",
+            "x": 0,
+            "y": 48,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Tank",
+            "Fighter"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 571.2,
+            "hpperlevel": 90,
+            "mp": 302.2,
+            "mpperlevel": 40,
+            "movespeed": 340,
+            "armor": 29,
+            "armorperlevel": 3.6,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 175,
+            "hpregen": 8.175,
+            "hpregenperlevel": 0.7,
+            "mpregen": 6.755,
+            "mpregenperlevel": 0.45,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 55.712,
+            "attackdamageperlevel": 3.4,
+            "attackspeedoffset": -0.05,
+            "attackspeedperlevel": 2.5
+          }
+        },
+        "Jax": {
+          "version": "6.22.1",
+          "id": "Jax",
+          "key": "24",
+          "name": "Jax",
+          "title": "Grandmaster at Arms",
+          "blurb": "It is seldom the case where a champion is defined by his actions after joining the League of Legends rather than before. Such is the case with Jax, for whom the argument could be made that he is the most prolific tournament fighter currently at the ...",
+          "info": {
+            "attack": 7,
+            "defense": 5,
+            "magic": 7,
+            "difficulty": 5
+          },
+          "image": {
+            "full": "Jax.png",
+            "sprite": "champion1.png",
+            "group": "champion",
+            "x": 48,
+            "y": 48,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Fighter",
+            "Assassin"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 592.8,
+            "hpperlevel": 85,
+            "mp": 338.8,
+            "mpperlevel": 32,
+            "movespeed": 350,
+            "armor": 27.04,
+            "armorperlevel": 3,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 8.37,
+            "hpregenperlevel": 0.55,
+            "mpregen": 7.575,
+            "mpregenperlevel": 0.7,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 61.97,
+            "attackdamageperlevel": 3.375,
+            "attackspeedoffset": -0.02,
+            "attackspeedperlevel": 3.4
+          }
+        },
+        "Jayce": {
+          "version": "6.22.1",
+          "id": "Jayce",
+          "key": "126",
+          "name": "Jayce",
+          "title": "the Defender of Tomorrow",
+          "blurb": "Armed with wit, charm, and his signature transforming hammer, Jayce lives to protect his native Piltover. Long before his nation called him a hero, however, he was a promising young inventor. When Piltover commissioned him to study a rare arcane ...",
+          "info": {
+            "attack": 8,
+            "defense": 4,
+            "magic": 3,
+            "difficulty": 7
+          },
+          "image": {
+            "full": "Jayce.png",
+            "sprite": "champion1.png",
+            "group": "champion",
+            "x": 96,
+            "y": 48,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Fighter",
+            "Marksman"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 571.2,
+            "hpperlevel": 90,
+            "mp": 357.2,
+            "mpperlevel": 37,
+            "movespeed": 335,
+            "armor": 22.38,
+            "armorperlevel": 3.5,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 125,
+            "hpregen": 7.34,
+            "hpregenperlevel": 0.8,
+            "mpregen": 6,
+            "mpregenperlevel": 0.8,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 50.38,
+            "attackdamageperlevel": 3.5,
+            "attackspeedoffset": -0.05,
+            "attackspeedperlevel": 3
+          }
+        },
+        "Jhin": {
+          "version": "6.22.1",
+          "id": "Jhin",
+          "key": "202",
+          "name": "Jhin",
+          "title": "the Virtuoso",
+          "blurb": "''Art requires a certain...cruelty.''<br><br>Jhin is a meticulous criminal psychopath who believes murder is art. Once an Ionian prisoner, but freed by shadowy elements within Ionia's ruling council, the serial killer now works as their cabal's ...",
+          "info": {
+            "attack": 10,
+            "defense": 2,
+            "magic": 6,
+            "difficulty": 6
+          },
+          "image": {
+            "full": "Jhin.png",
+            "sprite": "champion1.png",
+            "group": "champion",
+            "x": 144,
+            "y": 48,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Marksman",
+            "Assassin"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 540,
+            "hpperlevel": 85,
+            "mp": 300,
+            "mpperlevel": 50,
+            "movespeed": 330,
+            "armor": 20,
+            "armorperlevel": 3.5,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 550,
+            "hpregen": 6,
+            "hpregenperlevel": 0.55,
+            "mpregen": 6,
+            "mpregenperlevel": 0.8,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 53,
+            "attackdamageperlevel": 4,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 0
+          }
+        },
+        "Jinx": {
+          "version": "6.22.1",
+          "id": "Jinx",
+          "key": "222",
+          "name": "Jinx",
+          "title": "the Loose Cannon",
+          "blurb": "Jinx lives to wreak havoc without a thought for the consequences, leaving a trail of mayhem and panic in her wake. A manic and impulsive criminal, she despises nothing more than boredom, and gleefully brings her own volatile brand of pandemonium to ...",
+          "info": {
+            "attack": 9,
+            "defense": 2,
+            "magic": 4,
+            "difficulty": 6
+          },
+          "image": {
+            "full": "Jinx.png",
+            "sprite": "champion1.png",
+            "group": "champion",
+            "x": 192,
+            "y": 48,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Marksman"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 517.76,
+            "hpperlevel": 82,
+            "mp": 245.6,
+            "mpperlevel": 45,
+            "movespeed": 325,
+            "armor": 22.88,
+            "armorperlevel": 3.5,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 525,
+            "hpregen": 5.84,
+            "hpregenperlevel": 0.5,
+            "mpregen": 6.68,
+            "mpregenperlevel": 1,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 58.46,
+            "attackdamageperlevel": 2.41,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 1
+          }
+        },
+        "Kalista": {
+          "version": "6.22.1",
+          "id": "Kalista",
+          "key": "429",
+          "name": "Kalista",
+          "title": "the Spear of Vengeance",
+          "blurb": "''When wronged, we seek justice. When hurt, we strike back. When betrayed, the Spear of Vengeance strikes!''<br><br>A specter of wrath and retribution, Kalista is the undying spirit of vengeance, an armored nightmare summoned from the Shadow Isles to ...",
+          "info": {
+            "attack": 8,
+            "defense": 2,
+            "magic": 4,
+            "difficulty": 7
+          },
+          "image": {
+            "full": "Kalista.png",
+            "sprite": "champion1.png",
+            "group": "champion",
+            "x": 240,
+            "y": 48,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Marksman"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 517.76,
+            "hpperlevel": 83,
+            "mp": 231.8,
+            "mpperlevel": 35,
+            "movespeed": 325,
+            "armor": 19.012,
+            "armorperlevel": 3.5,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 550,
+            "hpregen": 6,
+            "hpregenperlevel": 0.55,
+            "mpregen": 6.3,
+            "mpregenperlevel": 0.4,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 63,
+            "attackdamageperlevel": 2.9,
+            "attackspeedoffset": -0.03,
+            "attackspeedperlevel": 2.5
+          }
+        },
+        "Karma": {
+          "version": "6.22.1",
+          "id": "Karma",
+          "key": "43",
+          "name": "Karma",
+          "title": "the Enlightened One",
+          "blurb": "Karma is a woman of indomitable will and unbound spiritual power. She is the soul of Ionia made manifest and an inspiring presence on the battlefield, shielding her allies and turning back her foes. A strong leader torn between tradition and ...",
+          "info": {
+            "attack": 1,
+            "defense": 7,
+            "magic": 8,
+            "difficulty": 5
+          },
+          "image": {
+            "full": "Karma.png",
+            "sprite": "champion1.png",
+            "group": "champion",
+            "x": 288,
+            "y": 48,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Mage",
+            "Support"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 522.44,
+            "hpperlevel": 83,
+            "mp": 374,
+            "mpperlevel": 50,
+            "movespeed": 335,
+            "armor": 20.384,
+            "armorperlevel": 3.8,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 525,
+            "hpregen": 5.62,
+            "hpregenperlevel": 0.55,
+            "mpregen": 8.5,
+            "mpregenperlevel": 0.8,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 53.544,
+            "attackdamageperlevel": 3.3,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 2.3
+          }
+        },
+        "Karthus": {
+          "version": "6.22.1",
+          "id": "Karthus",
+          "key": "30",
+          "name": "Karthus",
+          "title": "the Deathsinger",
+          "blurb": "''Death is not the end of the journey, it is just the beginning...''<br><br>The harbinger of oblivion, Karthus is an undying spirit whose haunting songs are a prelude to the horror of his nightmarish appearance. The living fear the eternity of undeath,...",
+          "info": {
+            "attack": 2,
+            "defense": 2,
+            "magic": 10,
+            "difficulty": 7
+          },
+          "image": {
+            "full": "Karthus.png",
+            "sprite": "champion1.png",
+            "group": "champion",
+            "x": 336,
+            "y": 48,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Mage"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 516,
+            "hpperlevel": 75,
+            "mp": 372.48,
+            "mpperlevel": 61,
+            "movespeed": 335,
+            "armor": 20.88,
+            "armorperlevel": 3.5,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 450,
+            "hpregen": 6.42,
+            "hpregenperlevel": 0.55,
+            "mpregen": 6,
+            "mpregenperlevel": 0.8,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 45.66,
+            "attackdamageperlevel": 3.25,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 2.11
+          }
+        },
+        "Kassadin": {
+          "version": "6.22.1",
+          "id": "Kassadin",
+          "key": "38",
+          "name": "Kassadin",
+          "title": "the Void Walker",
+          "blurb": "There is a place between dimensions and between worlds. To some it is known as the Outside, to others it is the Unknown. To most, however, it is called the Void. Despite its name, the Void is not an empty place, but rather the home of unspeakable ...",
+          "info": {
+            "attack": 3,
+            "defense": 5,
+            "magic": 8,
+            "difficulty": 8
+          },
+          "image": {
+            "full": "Kassadin.png",
+            "sprite": "champion1.png",
+            "group": "champion",
+            "x": 384,
+            "y": 48,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Assassin",
+            "Mage"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 564.04,
+            "hpperlevel": 78,
+            "mp": 397.6,
+            "mpperlevel": 67,
+            "movespeed": 340,
+            "armor": 23.376,
+            "armorperlevel": 3.2,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 150,
+            "hpregen": 7.79,
+            "hpregenperlevel": 0.5,
+            "mpregen": 6,
+            "mpregenperlevel": 0.8,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 58.852,
+            "attackdamageperlevel": 3.9,
+            "attackspeedoffset": -0.023,
+            "attackspeedperlevel": 3.7
+          }
+        },
+        "Katarina": {
+          "version": "6.22.1",
+          "id": "Katarina",
+          "key": "55",
+          "name": "Katarina",
+          "title": "the Sinister Blade",
+          "blurb": "Driven by an intense killer instinct, Katarina uses her talents as an assassin for the glory of Noxus, and the continued elevation of her family. While her fervor drives her to ever-greater feats, it can sometimes lead her astray.<br><br>From ...",
+          "info": {
+            "attack": 4,
+            "defense": 3,
+            "magic": 9,
+            "difficulty": 8
+          },
+          "image": {
+            "full": "Katarina.png",
+            "sprite": "champion1.png",
+            "group": "champion",
+            "x": 432,
+            "y": 48,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Assassin",
+            "Mage"
+          ],
+          "partype": "None",
+          "stats": {
+            "hp": 590,
+            "hpperlevel": 82,
+            "mp": 0,
+            "mpperlevel": 0,
+            "movespeed": 340,
+            "armor": 27.88,
+            "armorperlevel": 3.5,
+            "spellblock": 34.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 7.5,
+            "hpregenperlevel": 0.7,
+            "mpregen": 0,
+            "mpregenperlevel": 0,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 58,
+            "attackdamageperlevel": 3.2,
+            "attackspeedoffset": -0.05,
+            "attackspeedperlevel": 2.74
+          }
+        },
+        "Kayle": {
+          "version": "6.22.1",
+          "id": "Kayle",
+          "key": "10",
+          "name": "Kayle",
+          "title": "The Judicator",
+          "blurb": "In a world far away where an ancient war still rages, Kayle was a great hero - the strongest of an immortal race committed to destroying evil wherever it could be found. For ten thousand years, Kayle fought tirelessly for her people, wielding her ...",
+          "info": {
+            "attack": 6,
+            "defense": 6,
+            "magic": 7,
+            "difficulty": 7
+          },
+          "image": {
+            "full": "Kayle.png",
+            "sprite": "champion1.png",
+            "group": "champion",
+            "x": 0,
+            "y": 96,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Fighter",
+            "Support"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 574.24,
+            "hpperlevel": 93,
+            "mp": 322.2,
+            "mpperlevel": 40,
+            "movespeed": 335,
+            "armor": 26.88,
+            "armorperlevel": 3.5,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 125,
+            "hpregen": 8.26,
+            "hpregenperlevel": 0.75,
+            "mpregen": 6,
+            "mpregenperlevel": 0.8,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 51,
+            "attackdamageperlevel": 2.8,
+            "attackspeedoffset": -0.02,
+            "attackspeedperlevel": 2.2
+          }
+        },
+        "Kennen": {
+          "version": "6.22.1",
+          "id": "Kennen",
+          "key": "85",
+          "name": "Kennen",
+          "title": "the Heart of the Tempest",
+          "blurb": "There exists an ancient order originating in the Ionian Isles dedicated to the preservation of balance. Order, chaos, light, darkness -- all things must exist in perfect harmony for such is the way of the universe. This order is known as the Kinkou ...",
+          "info": {
+            "attack": 6,
+            "defense": 4,
+            "magic": 7,
+            "difficulty": 4
+          },
+          "image": {
+            "full": "Kennen.png",
+            "sprite": "champion1.png",
+            "group": "champion",
+            "x": 48,
+            "y": 96,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Mage",
+            "Marksman"
+          ],
+          "partype": "Energy",
+          "stats": {
+            "hp": 535.72,
+            "hpperlevel": 79,
+            "mp": 200,
+            "mpperlevel": 0,
+            "movespeed": 335,
+            "armor": 24.3,
+            "armorperlevel": 3.75,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 550,
+            "hpregen": 5.59,
+            "hpregenperlevel": 0.65,
+            "mpregen": 50,
+            "mpregenperlevel": 0,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 50.544,
+            "attackdamageperlevel": 3.3,
+            "attackspeedoffset": -0.0947,
+            "attackspeedperlevel": 3.4
+          }
+        },
+        "Khazix": {
+          "version": "6.22.1",
+          "id": "Khazix",
+          "key": "121",
+          "name": "Kha'Zix",
+          "title": "the Voidreaver",
+          "blurb": "A vicious Void predator, Kha'Zix infiltrated Valoran to devour the land's most promising creatures. With each kill he absorbs his prey's strength, evolving to grow more powerful. Kha'Zix hungers most to conquer and consume Rengar, the one beast he ...",
+          "info": {
+            "attack": 9,
+            "defense": 4,
+            "magic": 3,
+            "difficulty": 6
+          },
+          "image": {
+            "full": "Khazix.png",
+            "sprite": "champion1.png",
+            "group": "champion",
+            "x": 96,
+            "y": 96,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Assassin",
+            "Fighter"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 572.8,
+            "hpperlevel": 85,
+            "mp": 327.2,
+            "mpperlevel": 40,
+            "movespeed": 350,
+            "armor": 27,
+            "armorperlevel": 3,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 7.51,
+            "hpregenperlevel": 0.75,
+            "mpregen": 7.59,
+            "mpregenperlevel": 0.5,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 55.21,
+            "attackdamageperlevel": 3.1,
+            "attackspeedoffset": -0.065,
+            "attackspeedperlevel": 2.7
+          }
+        },
+        "Kindred": {
+          "version": "6.22.1",
+          "id": "Kindred",
+          "key": "203",
+          "name": "Kindred",
+          "title": "The Eternal Hunters",
+          "blurb": "''Tell me again, little Lamb, which things are ours to take?''<br>''All things, Dear Wolf.''<br>Separate, but never parted, Kindred represents the twin essences of death. Lamb's arrow offers a swift release for those who accept their fate. Wolf hunts ...",
+          "info": {
+            "attack": 8,
+            "defense": 2,
+            "magic": 2,
+            "difficulty": 4
+          },
+          "image": {
+            "full": "Kindred.png",
+            "sprite": "champion1.png",
+            "group": "champion",
+            "x": 144,
+            "y": 96,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Marksman"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 540,
+            "hpperlevel": 85,
+            "mp": 300,
+            "mpperlevel": 35,
+            "movespeed": 325,
+            "armor": 20,
+            "armorperlevel": 3.5,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 500,
+            "hpregen": 7,
+            "hpregenperlevel": 0.55,
+            "mpregen": 6.97,
+            "mpregenperlevel": 0.4,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 54,
+            "attackdamageperlevel": 1.7,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 2.5
+          }
+        },
+        "Kled": {
+          "version": "6.22.1",
+          "id": "Kled",
+          "key": "240",
+          "name": "Kled",
+          "title": "the Cantankerous Cavalier",
+          "blurb": "''A sane man would run . . . but I ain't the runnin' kind!''<br><br>A warrior as fearless as he is ornery, Kled is a popular folk hero in Noxus. Embodying the furious bravado of his nation, he is an icon beloved by the empire's soldiers, distrusted by ...",
+          "info": {
+            "attack": 8,
+            "defense": 2,
+            "magic": 2,
+            "difficulty": 7
+          },
+          "image": {
+            "full": "Kled.png",
+            "sprite": "champion4.png",
+            "group": "champion",
+            "x": 48,
+            "y": 48,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Fighter",
+            "Tank"
+          ],
+          "partype": "Gnarfury",
+          "stats": {
+            "hp": 340,
+            "hpperlevel": 70,
+            "mp": 100,
+            "mpperlevel": 0,
+            "movespeed": 345,
+            "armor": 26,
+            "armorperlevel": 4,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 6,
+            "hpregenperlevel": 0.75,
+            "mpregen": 0,
+            "mpregenperlevel": 0,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 55,
+            "attackdamageperlevel": 3,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 3.5
+          }
+        },
+        "KogMaw": {
+          "version": "6.22.1",
+          "id": "KogMaw",
+          "key": "96",
+          "name": "Kog'Maw",
+          "title": "the Mouth of the Abyss",
+          "blurb": "''If that's just hungry, I don't want to see angry.''<br><br>When the prophet Malzahar was reborn in Icathia, he was led there by an ominous voice which thereafter anchored itself to his psyche. From within, this voice bestowed upon him terrible ...",
+          "info": {
+            "attack": 8,
+            "defense": 2,
+            "magic": 5,
+            "difficulty": 6
+          },
+          "image": {
+            "full": "KogMaw.png",
+            "sprite": "champion1.png",
+            "group": "champion",
+            "x": 192,
+            "y": 96,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Marksman",
+            "Mage"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 517.76,
+            "hpperlevel": 82,
+            "mp": 322.2,
+            "mpperlevel": 40,
+            "movespeed": 325,
+            "armor": 19.88,
+            "armorperlevel": 3.5,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 500,
+            "hpregen": 5.92,
+            "hpregenperlevel": 0.55,
+            "mpregen": 8.675,
+            "mpregenperlevel": 0.7,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 57.46,
+            "attackdamageperlevel": 2.41,
+            "attackspeedoffset": -0.06,
+            "attackspeedperlevel": 2.65
+          }
+        },
+        "Leblanc": {
+          "version": "6.22.1",
+          "id": "Leblanc",
+          "key": "7",
+          "name": "LeBlanc",
+          "title": "the Deceiver",
+          "blurb": "Every city has its dark side, even one whose reputation is already of a questionable hue. Noxus - though its name is already invoked with a mixture of reverence and revulsion - is no exception to this simple truth. Deep within the winding dungeons ...",
+          "info": {
+            "attack": 1,
+            "defense": 4,
+            "magic": 10,
+            "difficulty": 9
+          },
+          "image": {
+            "full": "Leblanc.png",
+            "sprite": "champion1.png",
+            "group": "champion",
+            "x": 240,
+            "y": 96,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Assassin",
+            "Mage"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 516,
+            "hpperlevel": 80,
+            "mp": 334,
+            "mpperlevel": 50,
+            "movespeed": 340,
+            "armor": 21.88,
+            "armorperlevel": 3.5,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 525,
+            "hpregen": 8.5,
+            "hpregenperlevel": 0.8,
+            "mpregen": 6,
+            "mpregenperlevel": 0.8,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 54.88,
+            "attackdamageperlevel": 3.5,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 1.4
+          }
+        },
+        "LeeSin": {
+          "version": "6.22.1",
+          "id": "LeeSin",
+          "key": "64",
+          "name": "Lee Sin",
+          "title": "the Blind Monk",
+          "blurb": "As a young teen, Lee Sin was intent on becoming a summoner. His will and dedication were unmatched by any of his peers, and his skill drew the attention of Reginald Ashram, the League's High Councilor at the time. While studying at the Arcanum Majoris,...",
+          "info": {
+            "attack": 8,
+            "defense": 5,
+            "magic": 3,
+            "difficulty": 6
+          },
+          "image": {
+            "full": "LeeSin.png",
+            "sprite": "champion1.png",
+            "group": "champion",
+            "x": 288,
+            "y": 96,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Fighter",
+            "Assassin"
+          ],
+          "partype": "Energy",
+          "stats": {
+            "hp": 570.8,
+            "hpperlevel": 85,
+            "mp": 200,
+            "mpperlevel": 0,
+            "movespeed": 350,
+            "armor": 24.216,
+            "armorperlevel": 3.7,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 7.425,
+            "hpregenperlevel": 0.7,
+            "mpregen": 50,
+            "mpregenperlevel": 0,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 61.176,
+            "attackdamageperlevel": 3.2,
+            "attackspeedoffset": -0.04,
+            "attackspeedperlevel": 3
+          }
+        },
+        "Leona": {
+          "version": "6.22.1",
+          "id": "Leona",
+          "key": "89",
+          "name": "Leona",
+          "title": "the Radiant Dawn",
+          "blurb": "''If you would shine like a sun, first you must burn like one.''<br><br>Imbued with the fire of the sun, Leona is a warrior templar of the Solari who defends Mount Targon with her Zenith Blade and Shield of Daybreak. Her skin shimmers with starfire ...",
+          "info": {
+            "attack": 4,
+            "defense": 8,
+            "magic": 3,
+            "difficulty": 4
+          },
+          "image": {
+            "full": "Leona.png",
+            "sprite": "champion1.png",
+            "group": "champion",
+            "x": 336,
+            "y": 96,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Tank",
+            "Support"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 576.16,
+            "hpperlevel": 87,
+            "mp": 302.2,
+            "mpperlevel": 40,
+            "movespeed": 335,
+            "armor": 27.208,
+            "armorperlevel": 3.6,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 8.425,
+            "hpregenperlevel": 0.85,
+            "mpregen": 6,
+            "mpregenperlevel": 0.8,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 60.04,
+            "attackdamageperlevel": 3,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 2.9
+          }
+        },
+        "Lissandra": {
+          "version": "6.22.1",
+          "id": "Lissandra",
+          "key": "127",
+          "name": "Lissandra",
+          "title": "the Ice Witch",
+          "blurb": "Lissandra's magic twists the pure power of ice into something dark and terrible. With the force of her black ice, she does more than freeze - she impales and crushes those who oppose her. To the terrified denizens of the north, she is known only as ...",
+          "info": {
+            "attack": 2,
+            "defense": 5,
+            "magic": 8,
+            "difficulty": 6
+          },
+          "image": {
+            "full": "Lissandra.png",
+            "sprite": "champion1.png",
+            "group": "champion",
+            "x": 384,
+            "y": 96,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Mage"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 506.12,
+            "hpperlevel": 75,
+            "mp": 304,
+            "mpperlevel": 50,
+            "movespeed": 325,
+            "armor": 20.216,
+            "armorperlevel": 3.7,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 550,
+            "hpregen": 6.92,
+            "hpregenperlevel": 0.55,
+            "mpregen": 5.67,
+            "mpregenperlevel": 0.4,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 50.536,
+            "attackdamageperlevel": 2.7,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 1.36
+          }
+        },
+        "Lucian": {
+          "version": "6.22.1",
+          "id": "Lucian",
+          "key": "236",
+          "name": "Lucian",
+          "title": "the Purifier",
+          "blurb": "Lucian wields relic weapons imbued with ancient power and stands a stalwart guardian against the undead. His cold conviction never wavers, even in the face of the maddening horrors he destroys beneath his hail of purifying fire. Lucian walks alone on ...",
+          "info": {
+            "attack": 8,
+            "defense": 5,
+            "magic": 3,
+            "difficulty": 6
+          },
+          "image": {
+            "full": "Lucian.png",
+            "sprite": "champion1.png",
+            "group": "champion",
+            "x": 432,
+            "y": 96,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Marksman"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 554.4,
+            "hpperlevel": 80,
+            "mp": 348.88,
+            "mpperlevel": 38,
+            "movespeed": 335,
+            "armor": 24.04,
+            "armorperlevel": 3,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 500,
+            "hpregen": 6.19,
+            "hpregenperlevel": 0.65,
+            "mpregen": 8.175,
+            "mpregenperlevel": 0.7,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 57.46,
+            "attackdamageperlevel": 2.41,
+            "attackspeedoffset": -0.02,
+            "attackspeedperlevel": 3.3
+          }
+        },
+        "Lulu": {
+          "version": "6.22.1",
+          "id": "Lulu",
+          "key": "117",
+          "name": "Lulu",
+          "title": "the Fae Sorceress",
+          "blurb": "Perhaps more than any other champion in the League, Lulu marches to the beat of her own drum. During her youth in Bandle City, she spent most of her time wandering alone in the forest or lost in a daydream. It wasn't that she was antisocial; the ...",
+          "info": {
+            "attack": 4,
+            "defense": 5,
+            "magic": 7,
+            "difficulty": 5
+          },
+          "image": {
+            "full": "Lulu.png",
+            "sprite": "champion2.png",
+            "group": "champion",
+            "x": 0,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Support",
+            "Mage"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 552.76,
+            "hpperlevel": 74,
+            "mp": 350,
+            "mpperlevel": 55,
+            "movespeed": 330,
+            "armor": 19.216,
+            "armorperlevel": 3.7,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 550,
+            "hpregen": 6.005,
+            "hpregenperlevel": 0.6,
+            "mpregen": 11,
+            "mpregenperlevel": 0.6,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 46.368,
+            "attackdamageperlevel": 2.6,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 2.25
+          }
+        },
+        "Lux": {
+          "version": "6.22.1",
+          "id": "Lux",
+          "key": "99",
+          "name": "Lux",
+          "title": "the Lady of Luminosity",
+          "blurb": "Born to the prestigious Crownguards, the paragon family of Demacian service, Luxanna was destined for greatness. She grew up as the family's only daughter, and she immediately took to the advanced education and lavish parties required of families as ...",
+          "info": {
+            "attack": 2,
+            "defense": 4,
+            "magic": 9,
+            "difficulty": 5
+          },
+          "image": {
+            "full": "Lux.png",
+            "sprite": "champion2.png",
+            "group": "champion",
+            "x": 48,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Mage",
+            "Support"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 477.72,
+            "hpperlevel": 79,
+            "mp": 384,
+            "mpperlevel": 47,
+            "movespeed": 330,
+            "armor": 18.72,
+            "armorperlevel": 4,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 550,
+            "hpregen": 5.42,
+            "hpregenperlevel": 0.55,
+            "mpregen": 6,
+            "mpregenperlevel": 0.8,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 53.544,
+            "attackdamageperlevel": 3.3,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 1.36
+          }
+        },
+        "Malphite": {
+          "version": "6.22.1",
+          "id": "Malphite",
+          "key": "54",
+          "name": "Malphite",
+          "title": "Shard of the Monolith",
+          "blurb": "There is a world of perfect harmony, where all are part of the whole. The Monolith is the essence of all creation, and its denizens are but singular pieces of it. It is beautiful in its symmetry, and in its almost complete lack of uncertainty. The ...",
+          "info": {
+            "attack": 5,
+            "defense": 9,
+            "magic": 7,
+            "difficulty": 2
+          },
+          "image": {
+            "full": "Malphite.png",
+            "sprite": "champion2.png",
+            "group": "champion",
+            "x": 96,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Tank",
+            "Fighter"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 574.2,
+            "hpperlevel": 90,
+            "mp": 282.2,
+            "mpperlevel": 40,
+            "movespeed": 335,
+            "armor": 28.3,
+            "armorperlevel": 3.75,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 7,
+            "hpregenperlevel": 0.55,
+            "mpregen": 7.32,
+            "mpregenperlevel": 0.55,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 61.97,
+            "attackdamageperlevel": 3.375,
+            "attackspeedoffset": -0.02,
+            "attackspeedperlevel": 3.4
+          }
+        },
+        "Malzahar": {
+          "version": "6.22.1",
+          "id": "Malzahar",
+          "key": "90",
+          "name": "Malzahar",
+          "title": "the Prophet of the Void",
+          "blurb": "Many men have gone mad beneath the glare of the Shurima sun, but it was during the night's chilling embrace that Malzahar relinquished his sanity. Malzahar was born a seer, blessed with the gift of prophecy. His talent, though unrefined, promised to ...",
+          "info": {
+            "attack": 2,
+            "defense": 2,
+            "magic": 9,
+            "difficulty": 6
+          },
+          "image": {
+            "full": "Malzahar.png",
+            "sprite": "champion2.png",
+            "group": "champion",
+            "x": 144,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Mage",
+            "Assassin"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 525,
+            "hpperlevel": 75,
+            "mp": 300,
+            "mpperlevel": 55,
+            "movespeed": 335,
+            "armor": 20,
+            "armorperlevel": 3.5,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 500,
+            "hpregen": 6,
+            "hpregenperlevel": 0.6,
+            "mpregen": 6,
+            "mpregenperlevel": 0.8,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 55,
+            "attackdamageperlevel": 3,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 1.5
+          }
+        },
+        "Maokai": {
+          "version": "6.22.1",
+          "id": "Maokai",
+          "key": "57",
+          "name": "Maokai",
+          "title": "the Twisted Treant",
+          "blurb": "''All around me are empty husks, soulless and unafraid... but I will bring them fear.''<br><br>Maokai is a rageful, towering treant who fights the unnatural horrors of the Shadow Isles. He was twisted into a force of vengeance after a magical ...",
+          "info": {
+            "attack": 3,
+            "defense": 8,
+            "magic": 6,
+            "difficulty": 3
+          },
+          "image": {
+            "full": "Maokai.png",
+            "sprite": "champion2.png",
+            "group": "champion",
+            "x": 192,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Tank",
+            "Mage"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 572.2,
+            "hpperlevel": 90,
+            "mp": 377.28,
+            "mpperlevel": 43,
+            "movespeed": 335,
+            "armor": 28.72,
+            "armorperlevel": 4,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 7,
+            "hpregenperlevel": 0.75,
+            "mpregen": 7.205,
+            "mpregenperlevel": 0.45,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 63.544,
+            "attackdamageperlevel": 3.3,
+            "attackspeedoffset": -0.1,
+            "attackspeedperlevel": 2.125
+          }
+        },
+        "MasterYi": {
+          "version": "6.22.1",
+          "id": "MasterYi",
+          "key": "11",
+          "name": "Master Yi",
+          "title": "the Wuju Bladesman",
+          "blurb": "Through the ancient martial art of Wuju, Master Yi has tempered his body and sharpened his mind until thought and action have become one. Though he chooses to enter into violence as a last resort, the grace and speed with which he wields his blade ...",
+          "info": {
+            "attack": 10,
+            "defense": 4,
+            "magic": 2,
+            "difficulty": 4
+          },
+          "image": {
+            "full": "MasterYi.png",
+            "sprite": "champion2.png",
+            "group": "champion",
+            "x": 240,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Assassin",
+            "Fighter"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 598.56,
+            "hpperlevel": 92,
+            "mp": 250.56,
+            "mpperlevel": 42,
+            "movespeed": 355,
+            "armor": 24.04,
+            "armorperlevel": 3,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 7.59,
+            "hpregenperlevel": 0.65,
+            "mpregen": 7.255,
+            "mpregenperlevel": 0.45,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 60.04,
+            "attackdamageperlevel": 3,
+            "attackspeedoffset": -0.08,
+            "attackspeedperlevel": 2
+          }
+        },
+        "MissFortune": {
+          "version": "6.22.1",
+          "id": "MissFortune",
+          "key": "21",
+          "name": "Miss Fortune",
+          "title": "the Bounty Hunter",
+          "blurb": "''The bigger the risk, the bigger the bounty.''<br><br>Beauty and danger: There are few who can match Miss Fortune in either. One of Bilgewater's most infamous bounty hunters, she built her legend upon a swathe of bullet-riddled corpses and captured ...",
+          "info": {
+            "attack": 8,
+            "defense": 2,
+            "magic": 5,
+            "difficulty": 1
+          },
+          "image": {
+            "full": "MissFortune.png",
+            "sprite": "champion2.png",
+            "group": "champion",
+            "x": 288,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Marksman"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 530,
+            "hpperlevel": 85,
+            "mp": 325.84,
+            "mpperlevel": 35,
+            "movespeed": 325,
+            "armor": 24.04,
+            "armorperlevel": 3,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 550,
+            "hpregen": 6.19,
+            "hpregenperlevel": 0.65,
+            "mpregen": 8.04,
+            "mpregenperlevel": 0.65,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 46,
+            "attackdamageperlevel": 1,
+            "attackspeedoffset": -0.04734,
+            "attackspeedperlevel": 3
+          }
+        },
+        "MonkeyKing": {
+          "version": "6.22.1",
+          "id": "MonkeyKing",
+          "key": "62",
+          "name": "Wukong",
+          "title": "the Monkey King",
+          "blurb": "During the chaos of the Rune Wars, an enormous runestone was lost deep within the Plague Jungles. It remained there, untouched for centuries, emanating a potent magic which infused nearby wildlife with sentience and vitality. A group of monkeys who ...",
+          "info": {
+            "attack": 8,
+            "defense": 5,
+            "magic": 2,
+            "difficulty": 3
+          },
+          "image": {
+            "full": "MonkeyKing.png",
+            "sprite": "champion2.png",
+            "group": "champion",
+            "x": 336,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Fighter",
+            "Tank"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 577.8,
+            "hpperlevel": 85,
+            "mp": 265.84,
+            "mpperlevel": 38,
+            "movespeed": 345,
+            "armor": 24.88,
+            "armorperlevel": 3.5,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 175,
+            "hpregen": 6.19,
+            "hpregenperlevel": 0.65,
+            "mpregen": 8.04,
+            "mpregenperlevel": 0.65,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 59.876,
+            "attackdamageperlevel": 3.2,
+            "attackspeedoffset": -0.05,
+            "attackspeedperlevel": 3
+          }
+        },
+        "Mordekaiser": {
+          "version": "6.22.1",
+          "id": "Mordekaiser",
+          "key": "82",
+          "name": "Mordekaiser",
+          "title": "the Iron Revenant",
+          "blurb": "''All things must die... and yet I live on.''<br><br>The baleful revenant Mordekaiser is among the most terrifying and hateful spirits haunting the Shadow Isles. He has existed for countless centuries, shielded from true death by necromantic sorcery ...",
+          "info": {
+            "attack": 4,
+            "defense": 6,
+            "magic": 7,
+            "difficulty": 4
+          },
+          "image": {
+            "full": "Mordekaiser.png",
+            "sprite": "champion2.png",
+            "group": "champion",
+            "x": 384,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Fighter"
+          ],
+          "partype": "None",
+          "stats": {
+            "hp": 525,
+            "hpperlevel": 73,
+            "mp": 0,
+            "mpperlevel": 0,
+            "movespeed": 325,
+            "armor": 20,
+            "armorperlevel": 3.75,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 175,
+            "hpregen": 4,
+            "hpregenperlevel": 0.3,
+            "mpregen": 0,
+            "mpregenperlevel": 0,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 61,
+            "attackdamageperlevel": 5,
+            "attackspeedoffset": 0.04,
+            "attackspeedperlevel": 2.2
+          }
+        },
+        "Morgana": {
+          "version": "6.22.1",
+          "id": "Morgana",
+          "key": "25",
+          "name": "Morgana",
+          "title": "Fallen Angel",
+          "blurb": "There is a world far away populated by graceful and beautiful winged beings gifted with immortality, where an ancient conflict still rages. Like so many conflicts, this war split families. One side proclaimed themselves as beings of perfect order and ...",
+          "info": {
+            "attack": 1,
+            "defense": 6,
+            "magic": 8,
+            "difficulty": 1
+          },
+          "image": {
+            "full": "Morgana.png",
+            "sprite": "champion2.png",
+            "group": "champion",
+            "x": 432,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Mage",
+            "Support"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 547.48,
+            "hpperlevel": 86,
+            "mp": 340.8,
+            "mpperlevel": 60,
+            "movespeed": 335,
+            "armor": 25.384,
+            "armorperlevel": 3.8,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 450,
+            "hpregen": 5.705,
+            "hpregenperlevel": 0.6,
+            "mpregen": 8.5,
+            "mpregenperlevel": 0.8,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 55.46,
+            "attackdamageperlevel": 3.5,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 1.53
+          }
+        },
+        "Nami": {
+          "version": "6.22.1",
+          "id": "Nami",
+          "key": "267",
+          "name": "Nami",
+          "title": "the Tidecaller",
+          "blurb": "Nami channels the primal energies of the ocean, harnessing its mystical restorative properties and commanding the raw power of the tides themselves. Though many doubted her, Nami had the bravery and determination to take on a dangerous quest when no ...",
+          "info": {
+            "attack": 4,
+            "defense": 3,
+            "magic": 7,
+            "difficulty": 5
+          },
+          "image": {
+            "full": "Nami.png",
+            "sprite": "champion2.png",
+            "group": "champion",
+            "x": 0,
+            "y": 48,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Support",
+            "Mage"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 489.32,
+            "hpperlevel": 74,
+            "mp": 377.24,
+            "mpperlevel": 43,
+            "movespeed": 335,
+            "armor": 19.72,
+            "armorperlevel": 4,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 550,
+            "hpregen": 5.42,
+            "hpregenperlevel": 0.55,
+            "mpregen": 11.5,
+            "mpregenperlevel": 0.4,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 51.208,
+            "attackdamageperlevel": 3.1,
+            "attackspeedoffset": -0.03,
+            "attackspeedperlevel": 2.61
+          }
+        },
+        "Nasus": {
+          "version": "6.22.1",
+          "id": "Nasus",
+          "key": "75",
+          "name": "Nasus",
+          "title": "the Curator of the Sands",
+          "blurb": "''What was fallen will be great again.''<br><br>Nasus is an imposing, jackal-headed Ascended being from ancient Shurima, a heroic figure regarded as a demigod by the people of the desert. Fiercely intelligent, he was a guardian of knowledge and ...",
+          "info": {
+            "attack": 7,
+            "defense": 5,
+            "magic": 6,
+            "difficulty": 6
+          },
+          "image": {
+            "full": "Nasus.png",
+            "sprite": "champion2.png",
+            "group": "champion",
+            "x": 48,
+            "y": 48,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Fighter",
+            "Tank"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 561.2,
+            "hpperlevel": 90,
+            "mp": 325.6,
+            "mpperlevel": 42,
+            "movespeed": 350,
+            "armor": 24.88,
+            "armorperlevel": 3.5,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 9.01,
+            "hpregenperlevel": 0.9,
+            "mpregen": 7.44,
+            "mpregenperlevel": 0.5,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 59.18,
+            "attackdamageperlevel": 3.5,
+            "attackspeedoffset": -0.02,
+            "attackspeedperlevel": 3.48
+          }
+        },
+        "Nautilus": {
+          "version": "6.22.1",
+          "id": "Nautilus",
+          "key": "111",
+          "name": "Nautilus",
+          "title": "the Titan of the Depths",
+          "blurb": "Once, Nautilus was a sailor commissioned by the Institute of War to explore the uncharted reaches of the Guardian's Sea. This expedition took him deep into unknown waters where he and his crew found a vast section of black oozing liquid that none of ...",
+          "info": {
+            "attack": 4,
+            "defense": 6,
+            "magic": 6,
+            "difficulty": 6
+          },
+          "image": {
+            "full": "Nautilus.png",
+            "sprite": "champion2.png",
+            "group": "champion",
+            "x": 96,
+            "y": 48,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Tank",
+            "Fighter"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 576.48,
+            "hpperlevel": 86,
+            "mp": 334,
+            "mpperlevel": 47,
+            "movespeed": 325,
+            "armor": 26.46,
+            "armorperlevel": 3.75,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 175,
+            "hpregen": 8.37,
+            "hpregenperlevel": 0.55,
+            "mpregen": 8.625,
+            "mpregenperlevel": 0.7,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 57.544,
+            "attackdamageperlevel": 3.3,
+            "attackspeedoffset": 0.02,
+            "attackspeedperlevel": 1
+          }
+        },
+        "Nidalee": {
+          "version": "6.22.1",
+          "id": "Nidalee",
+          "key": "76",
+          "name": "Nidalee",
+          "title": "the Bestial Huntress",
+          "blurb": "There are few dwellers, let alone champions, residing in the blasted and dangerous lands that lie south of the Great Barrier. Much of that world still bears the scars of past Runes Wars, especially the mysterious Kumungu Jungle. There are ...",
+          "info": {
+            "attack": 5,
+            "defense": 4,
+            "magic": 7,
+            "difficulty": 8
+          },
+          "image": {
+            "full": "Nidalee.png",
+            "sprite": "champion2.png",
+            "group": "champion",
+            "x": 144,
+            "y": 48,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Assassin",
+            "Fighter"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 511.2,
+            "hpperlevel": 80,
+            "mp": 295.6,
+            "mpperlevel": 45,
+            "movespeed": 335,
+            "armor": 22.88,
+            "armorperlevel": 3.5,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 525,
+            "hpregen": 6.005,
+            "hpregenperlevel": 0.6,
+            "mpregen": 6,
+            "mpregenperlevel": 0.8,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 47.88,
+            "attackdamageperlevel": 3.5,
+            "attackspeedoffset": -0.02,
+            "attackspeedperlevel": 3.22
+          }
+        },
+        "Nocturne": {
+          "version": "6.22.1",
+          "id": "Nocturne",
+          "key": "56",
+          "name": "Nocturne",
+          "title": "the Eternal Nightmare",
+          "blurb": "Before Nocturne, people believed that dreams were figments of their imagination, meaningless images that flashed through the mind when one slept. This belief was put to the test when a rash of sleep-related incidents started afflicting summoners of ...",
+          "info": {
+            "attack": 9,
+            "defense": 5,
+            "magic": 2,
+            "difficulty": 4
+          },
+          "image": {
+            "full": "Nocturne.png",
+            "sprite": "champion2.png",
+            "group": "champion",
+            "x": 192,
+            "y": 48,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Assassin",
+            "Fighter"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 582.8,
+            "hpperlevel": 85,
+            "mp": 273.8,
+            "mpperlevel": 35,
+            "movespeed": 345,
+            "armor": 26.88,
+            "armorperlevel": 3.5,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 8.26,
+            "hpregenperlevel": 0.75,
+            "mpregen": 6.755,
+            "mpregenperlevel": 0.45,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 59.208,
+            "attackdamageperlevel": 3.1,
+            "attackspeedoffset": -0.065,
+            "attackspeedperlevel": 2.7
+          }
+        },
+        "Nunu": {
+          "version": "6.22.1",
+          "id": "Nunu",
+          "key": "20",
+          "name": "Nunu",
+          "title": "the Yeti Rider",
+          "blurb": "Sometimes bonds of friendship become stronger than even bonds of blood. When those bonds link a fearless boy to a fearsome Yeti, the bond becomes a force to be reckoned with. Given the responsibility of taming a terrifying beast, Nunu forged a ...",
+          "info": {
+            "attack": 4,
+            "defense": 6,
+            "magic": 7,
+            "difficulty": 4
+          },
+          "image": {
+            "full": "Nunu.png",
+            "sprite": "champion2.png",
+            "group": "champion",
+            "x": 240,
+            "y": 48,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Support",
+            "Fighter"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 598.28,
+            "hpperlevel": 90,
+            "mp": 283.56,
+            "mpperlevel": 42,
+            "movespeed": 350,
+            "armor": 26.38,
+            "armorperlevel": 3.5,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 8.39,
+            "hpregenperlevel": 0.8,
+            "mpregen": 7.44,
+            "mpregenperlevel": 0.5,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 59,
+            "attackdamageperlevel": 4,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 2.25
+          }
+        },
+        "Olaf": {
+          "version": "6.22.1",
+          "id": "Olaf",
+          "key": "2",
+          "name": "Olaf",
+          "title": "the Berserker",
+          "blurb": "Most men would say that death is a thing to be feared; none of those men would be Olaf. The Berserker lives only for the roar of a battle cry and the clash of steel. Spurred on by his hunger for glory and the looming curse of a forgettable death, Olaf ...",
+          "info": {
+            "attack": 9,
+            "defense": 5,
+            "magic": 3,
+            "difficulty": 3
+          },
+          "image": {
+            "full": "Olaf.png",
+            "sprite": "champion2.png",
+            "group": "champion",
+            "x": 288,
+            "y": 48,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Fighter",
+            "Tank"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 597.24,
+            "hpperlevel": 93,
+            "mp": 315.6,
+            "mpperlevel": 42,
+            "movespeed": 350,
+            "armor": 26.04,
+            "armorperlevel": 3,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 8.51,
+            "hpregenperlevel": 0.9,
+            "mpregen": 7.465,
+            "mpregenperlevel": 0.575,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 59.98,
+            "attackdamageperlevel": 3.5,
+            "attackspeedoffset": -0.1,
+            "attackspeedperlevel": 2.7
+          }
+        },
+        "Orianna": {
+          "version": "6.22.1",
+          "id": "Orianna",
+          "key": "61",
+          "name": "Orianna",
+          "title": "the Lady of Clockwork",
+          "blurb": "There once was a Piltovian man named Corin Reveck who had a daughter named Orianna, whom he loved more than anything else in the world. Though Orianna had incredible talent for dancing, she was deeply fascinated by the champions of the League of ...",
+          "info": {
+            "attack": 4,
+            "defense": 3,
+            "magic": 9,
+            "difficulty": 7
+          },
+          "image": {
+            "full": "Orianna.png",
+            "sprite": "champion2.png",
+            "group": "champion",
+            "x": 336,
+            "y": 48,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Mage",
+            "Support"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 517.72,
+            "hpperlevel": 79,
+            "mp": 334,
+            "mpperlevel": 50,
+            "movespeed": 325,
+            "armor": 17.04,
+            "armorperlevel": 3,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 525,
+            "hpregen": 6.87,
+            "hpregenperlevel": 0.55,
+            "mpregen": 6,
+            "mpregenperlevel": 0.8,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 40.368,
+            "attackdamageperlevel": 2.6,
+            "attackspeedoffset": -0.05,
+            "attackspeedperlevel": 3.5
+          }
+        },
+        "Pantheon": {
+          "version": "6.22.1",
+          "id": "Pantheon",
+          "key": "80",
+          "name": "Pantheon",
+          "title": "the Artisan of War",
+          "blurb": "''Bring forth one true champion, or a hundred more like you, and then we shall have a battle that will be spoken of until the end of time.''<br><br>The peerless warrior known as Pantheon is a nigh-unstoppable paragon of battle. He was born among the ...",
+          "info": {
+            "attack": 9,
+            "defense": 4,
+            "magic": 3,
+            "difficulty": 4
+          },
+          "image": {
+            "full": "Pantheon.png",
+            "sprite": "champion2.png",
+            "group": "champion",
+            "x": 384,
+            "y": 48,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Fighter",
+            "Assassin"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 579.16,
+            "hpperlevel": 87,
+            "mp": 317.12,
+            "mpperlevel": 31,
+            "movespeed": 355,
+            "armor": 27.652,
+            "armorperlevel": 3.9,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 150,
+            "hpregen": 7.84,
+            "hpregenperlevel": 0.65,
+            "mpregen": 7.355,
+            "mpregenperlevel": 0.45,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 55.572,
+            "attackdamageperlevel": 2.9,
+            "attackspeedoffset": -0.03,
+            "attackspeedperlevel": 2.95
+          }
+        },
+        "Poppy": {
+          "version": "6.22.1",
+          "id": "Poppy",
+          "key": "78",
+          "name": "Poppy",
+          "title": "Keeper of the Hammer",
+          "blurb": "''I'm no hero. Just a yordle with a hammer.''<br><br>Runeterra has no shortage of valiant champions, but few are as tenacious as Poppy. Bearing a hammer twice the length of her body, this determined yordle has spent untold years searching for the ...",
+          "info": {
+            "attack": 6,
+            "defense": 7,
+            "magic": 2,
+            "difficulty": 6
+          },
+          "image": {
+            "full": "Poppy.png",
+            "sprite": "champion2.png",
+            "group": "champion",
+            "x": 432,
+            "y": 48,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Tank",
+            "Fighter"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 540,
+            "hpperlevel": 90,
+            "mp": 280,
+            "mpperlevel": 40,
+            "movespeed": 345,
+            "armor": 29,
+            "armorperlevel": 3.5,
+            "spellblock": 32,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 8,
+            "hpregenperlevel": 0.8,
+            "mpregen": 7,
+            "mpregenperlevel": 0.7,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 56,
+            "attackdamageperlevel": 4,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 2.5
+          }
+        },
+        "Quinn": {
+          "version": "6.22.1",
+          "id": "Quinn",
+          "key": "133",
+          "name": "Quinn",
+          "title": "Demacia's Wings",
+          "blurb": "Quinn and Valor are an elite ranger team. With crossbow and claw, they undertake their nation's most dangerous missions deep within enemy territory, from swift reconnaissance to lethal strikes. The pair's unbreakable bond is deadly on the battlefield, ...",
+          "info": {
+            "attack": 9,
+            "defense": 4,
+            "magic": 2,
+            "difficulty": 5
+          },
+          "image": {
+            "full": "Quinn.png",
+            "sprite": "champion2.png",
+            "group": "champion",
+            "x": 0,
+            "y": 96,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Marksman",
+            "Fighter"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 532.8,
+            "hpperlevel": 85,
+            "mp": 268.8,
+            "mpperlevel": 35,
+            "movespeed": 335,
+            "armor": 23.38,
+            "armorperlevel": 3.5,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 525,
+            "hpregen": 5.42,
+            "hpregenperlevel": 0.55,
+            "mpregen": 6.97,
+            "mpregenperlevel": 0.4,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 54.46,
+            "attackdamageperlevel": 2.41,
+            "attackspeedoffset": -0.065,
+            "attackspeedperlevel": 3.1
+          }
+        },
+        "Rammus": {
+          "version": "6.22.1",
+          "id": "Rammus",
+          "key": "33",
+          "name": "Rammus",
+          "title": "the Armordillo",
+          "blurb": "''OK.''<br><br>Idolized by many, dismissed by some, mystifying to all, the curious being, Rammus, is an enigma. Protected by a spiked shell, Rammus inspires increasingly disparate theories on his origin wherever he goes - from demigod, to sacred ...",
+          "info": {
+            "attack": 4,
+            "defense": 10,
+            "magic": 5,
+            "difficulty": 5
+          },
+          "image": {
+            "full": "Rammus.png",
+            "sprite": "champion2.png",
+            "group": "champion",
+            "x": 48,
+            "y": 96,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Tank",
+            "Fighter"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 564.48,
+            "hpperlevel": 86,
+            "mp": 310.44,
+            "mpperlevel": 33,
+            "movespeed": 335,
+            "armor": 31.384,
+            "armorperlevel": 4.3,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 7.92,
+            "hpregenperlevel": 0.55,
+            "mpregen": 7.84,
+            "mpregenperlevel": 0.5,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 55.88,
+            "attackdamageperlevel": 3.5,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 2.215
+          }
+        },
+        "RekSai": {
+          "version": "6.22.1",
+          "id": "RekSai",
+          "key": "421",
+          "name": "Rek'Sai",
+          "title": "the Void Burrower",
+          "blurb": "The largest and fiercest of her species, Rek'Sai is a merciless predator that tunnels through the earth to ambush and devour her prey. Her insatiable hunger has laid waste to entire regions of the once-great Shuriman empire. Merchants, traders and ...",
+          "info": {
+            "attack": 8,
+            "defense": 5,
+            "magic": 2,
+            "difficulty": 3
+          },
+          "image": {
+            "full": "RekSai.png",
+            "sprite": "champion2.png",
+            "group": "champion",
+            "x": 96,
+            "y": 96,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Fighter"
+          ],
+          "partype": "Battlefury",
+          "stats": {
+            "hp": 570,
+            "hpperlevel": 90,
+            "mp": 100,
+            "mpperlevel": 0,
+            "movespeed": 335,
+            "armor": 24,
+            "armorperlevel": 3.4,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 175,
+            "hpregen": 7.34,
+            "hpregenperlevel": 0.65,
+            "mpregen": 0,
+            "mpregenperlevel": 0,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 55.628,
+            "attackdamageperlevel": 3.35,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 2
+          }
+        },
+        "Renekton": {
+          "version": "6.22.1",
+          "id": "Renekton",
+          "key": "58",
+          "name": "Renekton",
+          "title": "the Butcher of the Sands",
+          "blurb": "''Blood and vengeance.''<br><br>Renekton is a terrifying, rage-fueled Ascended being from the scorched deserts of Shurima. Once, he was his empire's most esteemed warrior, leading the armies of Shurima to countless victories. However, after the ...",
+          "info": {
+            "attack": 8,
+            "defense": 5,
+            "magic": 2,
+            "difficulty": 3
+          },
+          "image": {
+            "full": "Renekton.png",
+            "sprite": "champion2.png",
+            "group": "champion",
+            "x": 144,
+            "y": 96,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Fighter",
+            "Tank"
+          ],
+          "partype": "Rage",
+          "stats": {
+            "hp": 572.16,
+            "hpperlevel": 87,
+            "mp": 100,
+            "mpperlevel": 0,
+            "movespeed": 345,
+            "armor": 25.584,
+            "armorperlevel": 3.8,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 7.96,
+            "hpregenperlevel": 0.75,
+            "mpregen": 0,
+            "mpregenperlevel": 0,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 58.328,
+            "attackdamageperlevel": 3.1,
+            "attackspeedoffset": -0.06,
+            "attackspeedperlevel": 2.65
+          }
+        },
+        "Rengar": {
+          "version": "6.22.1",
+          "id": "Rengar",
+          "key": "107",
+          "name": "Rengar",
+          "title": "the Pridestalker",
+          "blurb": "On every wall of his den, the trophy hunter Rengar mounts the heads, horns, claws, and fangs of the most lethal creatures in Valoran. Though his collection is extensive, he remains unsatisfied, tirelessly seeking greater game. He takes time with every ...",
+          "info": {
+            "attack": 7,
+            "defense": 4,
+            "magic": 2,
+            "difficulty": 8
+          },
+          "image": {
+            "full": "Rengar.png",
+            "sprite": "champion2.png",
+            "group": "champion",
+            "x": 192,
+            "y": 96,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Assassin",
+            "Fighter"
+          ],
+          "partype": "Ferocity",
+          "stats": {
+            "hp": 586.2,
+            "hpperlevel": 90,
+            "mp": 4,
+            "mpperlevel": 0,
+            "movespeed": 345,
+            "armor": 25.88,
+            "armorperlevel": 3,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 7,
+            "hpregenperlevel": 0.5,
+            "mpregen": 0,
+            "mpregenperlevel": 0,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 60,
+            "attackdamageperlevel": 1,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 3.5
+          }
+        },
+        "Riven": {
+          "version": "6.22.1",
+          "id": "Riven",
+          "key": "92",
+          "name": "Riven",
+          "title": "the Exile",
+          "blurb": "''There is a place between war and murder in which our demons lurk.''<br><br>In Noxus, any citizen may rise to power regardless of race, gender, or social standing - strength is all that matters. It was with committed faith in this ideal that Riven ...",
+          "info": {
+            "attack": 8,
+            "defense": 5,
+            "magic": 1,
+            "difficulty": 8
+          },
+          "image": {
+            "full": "Riven.png",
+            "sprite": "champion2.png",
+            "group": "champion",
+            "x": 240,
+            "y": 96,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Fighter",
+            "Assassin"
+          ],
+          "partype": "None",
+          "stats": {
+            "hp": 558.48,
+            "hpperlevel": 86,
+            "mp": 0,
+            "mpperlevel": 0,
+            "movespeed": 340,
+            "armor": 24.376,
+            "armorperlevel": 3.2,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 5.34,
+            "hpregenperlevel": 0.5,
+            "mpregen": 0,
+            "mpregenperlevel": 0,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 56.04,
+            "attackdamageperlevel": 3,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 3.5
+          }
+        },
+        "Rumble": {
+          "version": "6.22.1",
+          "id": "Rumble",
+          "key": "68",
+          "name": "Rumble",
+          "title": "the Mechanized Menace",
+          "blurb": "''Ugh, it's gonna take forever to scrape your face off my suit!''<br><br>Even amongst yordles, Rumble was always the runt of the litter. As such, he was used to being bullied. In order to survive, he had to be scrappier and more resourceful than his ...",
+          "info": {
+            "attack": 3,
+            "defense": 6,
+            "magic": 8,
+            "difficulty": 10
+          },
+          "image": {
+            "full": "Rumble.png",
+            "sprite": "champion2.png",
+            "group": "champion",
+            "x": 288,
+            "y": 96,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Fighter",
+            "Mage"
+          ],
+          "partype": "Heat",
+          "stats": {
+            "hp": 584.4,
+            "hpperlevel": 80,
+            "mp": 100,
+            "mpperlevel": 0,
+            "movespeed": 345,
+            "armor": 25.88,
+            "armorperlevel": 3.5,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 8.005,
+            "hpregenperlevel": 0.6,
+            "mpregen": 0,
+            "mpregenperlevel": 0,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 61.036,
+            "attackdamageperlevel": 3.2,
+            "attackspeedoffset": -0.03,
+            "attackspeedperlevel": 1.85
+          }
+        },
+        "Ryze": {
+          "version": "6.22.1",
+          "id": "Ryze",
+          "key": "13",
+          "name": "Ryze",
+          "title": "the Rune Mage",
+          "blurb": "''Take care with this world. What is made can be unmade.''<br><br>Widely considered one of the most adept sorcerers on Runeterra, Ryze is an ancient, hard-bitten archmage with an impossibly heavy burden to bear. Armed with a boundless constitution and ...",
+          "info": {
+            "attack": 2,
+            "defense": 2,
+            "magic": 10,
+            "difficulty": 7
+          },
+          "image": {
+            "full": "Ryze.png",
+            "sprite": "champion2.png",
+            "group": "champion",
+            "x": 336,
+            "y": 96,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Mage",
+            "Fighter"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 558.48,
+            "hpperlevel": 86,
+            "mp": 400,
+            "mpperlevel": 50,
+            "movespeed": 340,
+            "armor": 21.552,
+            "armorperlevel": 3,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 550,
+            "hpregen": 7,
+            "hpregenperlevel": 0.55,
+            "mpregen": 6,
+            "mpregenperlevel": 0.8,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 55.04,
+            "attackdamageperlevel": 3,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 2.112
+          }
+        },
+        "Sejuani": {
+          "version": "6.22.1",
+          "id": "Sejuani",
+          "key": "113",
+          "name": "Sejuani",
+          "title": "the Winter's Wrath",
+          "blurb": "Sejuani was weaned on hardship and reared on barbarity. Where others succumbed to the harshness of the Freljord, she was tempered by it until pain became power, hunger an encouragement, and frost an ally in culling the weak. Through her ordeals, she ...",
+          "info": {
+            "attack": 5,
+            "defense": 7,
+            "magic": 6,
+            "difficulty": 4
+          },
+          "image": {
+            "full": "Sejuani.png",
+            "sprite": "champion2.png",
+            "group": "champion",
+            "x": 384,
+            "y": 96,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Tank",
+            "Fighter"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 600,
+            "hpperlevel": 95,
+            "mp": 400,
+            "mpperlevel": 40,
+            "movespeed": 340,
+            "armor": 29.54,
+            "armorperlevel": 3,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 8.675,
+            "hpregenperlevel": 0.85,
+            "mpregen": 7.205,
+            "mpregenperlevel": 0.45,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 57.544,
+            "attackdamageperlevel": 3.3,
+            "attackspeedoffset": -0.0672,
+            "attackspeedperlevel": 1.44
+          }
+        },
+        "Shaco": {
+          "version": "6.22.1",
+          "id": "Shaco",
+          "key": "35",
+          "name": "Shaco",
+          "title": "the Demon Jester",
+          "blurb": "Most would say that death isn't funny. It isn't, unless you're Shaco - then it's hysterical. He is Valoran's first fully functioning homicidal comic; he jests until someone dies, and then he laughs. The figure that has come to be known as the Demon ...",
+          "info": {
+            "attack": 8,
+            "defense": 4,
+            "magic": 6,
+            "difficulty": 9
+          },
+          "image": {
+            "full": "Shaco.png",
+            "sprite": "champion2.png",
+            "group": "champion",
+            "x": 432,
+            "y": 96,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Assassin"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 582.12,
+            "hpperlevel": 84,
+            "mp": 297.2,
+            "mpperlevel": 40,
+            "movespeed": 350,
+            "armor": 24.88,
+            "armorperlevel": 3.5,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 8.37,
+            "hpregenperlevel": 0.55,
+            "mpregen": 7.155,
+            "mpregenperlevel": 0.45,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 57.58,
+            "attackdamageperlevel": 3.5,
+            "attackspeedoffset": -0.1,
+            "attackspeedperlevel": 3
+          }
+        },
+        "Shen": {
+          "version": "6.22.1",
+          "id": "Shen",
+          "key": "98",
+          "name": "Shen",
+          "title": "the Eye of Twilight",
+          "blurb": "''The Eye is blind to fear, to hate, to love - to all things that would sway equilibrium.''<br><br>Leader of a secret clan of mystic warriors, Shen serves as the Eye of Twilight, entrusted to enforce equilibrium in the world. Longing to remain free ...",
+          "info": {
+            "attack": 3,
+            "defense": 9,
+            "magic": 3,
+            "difficulty": 4
+          },
+          "image": {
+            "full": "Shen.png",
+            "sprite": "champion3.png",
+            "group": "champion",
+            "x": 0,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Tank",
+            "Melee"
+          ],
+          "partype": "Energy",
+          "stats": {
+            "hp": 540,
+            "hpperlevel": 73,
+            "mp": 400,
+            "mpperlevel": 0,
+            "movespeed": 340,
+            "armor": 25,
+            "armorperlevel": 2.6,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 8.5,
+            "hpregenperlevel": 0.75,
+            "mpregen": 50,
+            "mpregenperlevel": 0,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 60,
+            "attackdamageperlevel": 3,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 2
+          }
+        },
+        "Shyvana": {
+          "version": "6.22.1",
+          "id": "Shyvana",
+          "key": "102",
+          "name": "Shyvana",
+          "title": "the Half-Dragon",
+          "blurb": "A half-breed born from the union between dragon and human, Shyvana searched all her life for belonging. Persecution forged her into a brutal warrior, and those who dare stand against Shyvana face the fiery beast lurking just beneath her skin....",
+          "info": {
+            "attack": 8,
+            "defense": 6,
+            "magic": 3,
+            "difficulty": 4
+          },
+          "image": {
+            "full": "Shyvana.png",
+            "sprite": "champion3.png",
+            "group": "champion",
+            "x": 48,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Fighter",
+            "Tank"
+          ],
+          "partype": "Dragonfury",
+          "stats": {
+            "hp": 594.6,
+            "hpperlevel": 95,
+            "mp": 100,
+            "mpperlevel": 0,
+            "movespeed": 350,
+            "armor": 27.628,
+            "armorperlevel": 3.35,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 8.59,
+            "hpregenperlevel": 0.8,
+            "mpregen": 0,
+            "mpregenperlevel": 0,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 60.712,
+            "attackdamageperlevel": 3.4,
+            "attackspeedoffset": -0.05,
+            "attackspeedperlevel": 2.5
+          }
+        },
+        "Singed": {
+          "version": "6.22.1",
+          "id": "Singed",
+          "key": "27",
+          "name": "Singed",
+          "title": "the Mad Chemist",
+          "blurb": "Singed descended from a long line of Zaun's revered chemists. Even in his youth, his talent for concocting potions far outstripped that of his peers, and he quickly distinguished himself from his less extraordinary chemist compatriots. It came as no ...",
+          "info": {
+            "attack": 4,
+            "defense": 8,
+            "magic": 7,
+            "difficulty": 5
+          },
+          "image": {
+            "full": "Singed.png",
+            "sprite": "champion3.png",
+            "group": "champion",
+            "x": 96,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Tank",
+            "Fighter"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 542.76,
+            "hpperlevel": 82,
+            "mp": 290.6,
+            "mpperlevel": 45,
+            "movespeed": 345,
+            "armor": 27.88,
+            "armorperlevel": 3.5,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 8.02,
+            "hpregenperlevel": 0.55,
+            "mpregen": 7.52,
+            "mpregenperlevel": 0.55,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 62.32,
+            "attackdamageperlevel": 3.375,
+            "attackspeedoffset": 0.02,
+            "attackspeedperlevel": 1.81
+          }
+        },
+        "Sion": {
+          "version": "6.22.1",
+          "id": "Sion",
+          "key": "14",
+          "name": "Sion",
+          "title": "The Undead Juggernaut",
+          "blurb": "BLOOD.<br><br>SMELL IT.<br><br>WANT. ACHING. NEED!<br><br>CLOSE NOW. THEY COME.<br><br>NO CHAINS? FREE! KILL!<br><br>IN REACH. YES! DIE! DIE!<br><br>Gone. Too quick. No fight. More. I want... more.<br><br>A voice? Unfamiliar. I see him. The Grand ...",
+          "info": {
+            "attack": 5,
+            "defense": 9,
+            "magic": 3,
+            "difficulty": 5
+          },
+          "image": {
+            "full": "Sion.png",
+            "sprite": "champion3.png",
+            "group": "champion",
+            "x": 144,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Tank",
+            "Fighter"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 542.64,
+            "hpperlevel": 73,
+            "mp": 325.6,
+            "mpperlevel": 42,
+            "movespeed": 345,
+            "armor": 23.04,
+            "armorperlevel": 3,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 175,
+            "hpregen": 10.18,
+            "hpregenperlevel": 0.8,
+            "mpregen": 8.005,
+            "mpregenperlevel": 0.6,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 59.72,
+            "attackdamageperlevel": 4,
+            "attackspeedoffset": -0.08,
+            "attackspeedperlevel": 1.3
+          }
+        },
+        "Sivir": {
+          "version": "6.22.1",
+          "id": "Sivir",
+          "key": "15",
+          "name": "Sivir",
+          "title": "the Battle Mistress",
+          "blurb": "''I don't care what face is on your coin, as long as it pays.''<br><br>Sivir is a renowned fortune hunter and mercenary captain who plies her trade in the deserts of Shurima. Armed with her legendary jeweled crossblade, she has fought and won ...",
+          "info": {
+            "attack": 9,
+            "defense": 3,
+            "magic": 1,
+            "difficulty": 4
+          },
+          "image": {
+            "full": "Sivir.png",
+            "sprite": "champion3.png",
+            "group": "champion",
+            "x": 192,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Marksman"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 515.76,
+            "hpperlevel": 82,
+            "mp": 284,
+            "mpperlevel": 50,
+            "movespeed": 335,
+            "armor": 22.21,
+            "armorperlevel": 3.25,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 500,
+            "hpregen": 5.17,
+            "hpregenperlevel": 0.55,
+            "mpregen": 8.01,
+            "mpregenperlevel": 0.9,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 57.46,
+            "attackdamageperlevel": 2.41,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 1.6
+          }
+        },
+        "Skarner": {
+          "version": "6.22.1",
+          "id": "Skarner",
+          "key": "72",
+          "name": "Skarner",
+          "title": "the Crystal Vanguard",
+          "blurb": "''We are one. We cannot be shattered.''<br><br>Skarner is an immense crystalline scorpion from a hidden valley in Shurima. Part of the ancient Brackern race, Skarner and his kin are known for their great wisdom and deep connection to the land, as ...",
+          "info": {
+            "attack": 7,
+            "defense": 6,
+            "magic": 5,
+            "difficulty": 5
+          },
+          "image": {
+            "full": "Skarner.png",
+            "sprite": "champion3.png",
+            "group": "champion",
+            "x": 240,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Fighter",
+            "Tank"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 601.28,
+            "hpperlevel": 90,
+            "mp": 272.2,
+            "mpperlevel": 40,
+            "movespeed": 335,
+            "armor": 29.384,
+            "armorperlevel": 3.8,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 8.925,
+            "hpregenperlevel": 0.85,
+            "mpregen": 7.205,
+            "mpregenperlevel": 0.45,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 57.156,
+            "attackdamageperlevel": 4.5,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 2.1
+          }
+        },
+        "Sona": {
+          "version": "6.22.1",
+          "id": "Sona",
+          "key": "37",
+          "name": "Sona",
+          "title": "Maven of the Strings",
+          "blurb": "Sona has no memories of her true parents. As an infant, she was found abandoned on the doorstep of an Ionian adoption house, nestled atop an ancient instrument in an exquisite case of unknown origins. She was an unusually well-behaved child, always ...",
+          "info": {
+            "attack": 5,
+            "defense": 2,
+            "magic": 8,
+            "difficulty": 4
+          },
+          "image": {
+            "full": "Sona.png",
+            "sprite": "champion3.png",
+            "group": "champion",
+            "x": 288,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Support",
+            "Mage"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 482.36,
+            "hpperlevel": 77,
+            "mp": 340.6,
+            "mpperlevel": 45,
+            "movespeed": 325,
+            "armor": 20.544,
+            "armorperlevel": 3.3,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 550,
+            "hpregen": 5.42,
+            "hpregenperlevel": 0.55,
+            "mpregen": 11.5,
+            "mpregenperlevel": 0.4,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 50.04,
+            "attackdamageperlevel": 3,
+            "attackspeedoffset": -0.03,
+            "attackspeedperlevel": 2.3
+          }
+        },
+        "Soraka": {
+          "version": "6.22.1",
+          "id": "Soraka",
+          "key": "16",
+          "name": "Soraka",
+          "title": "the Starchild",
+          "blurb": "A healer gifted with the magic of the stars, Soraka holds all living creatures close to her heart. She was once a celestial being, but she sacrificed her immortality and entered the world of mortals. So long as evil threatens life in Valoran, Soraka ...",
+          "info": {
+            "attack": 2,
+            "defense": 5,
+            "magic": 7,
+            "difficulty": 3
+          },
+          "image": {
+            "full": "Soraka.png",
+            "sprite": "champion3.png",
+            "group": "champion",
+            "x": 336,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Support",
+            "Mage"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 529.04,
+            "hpperlevel": 78,
+            "mp": 350.8,
+            "mpperlevel": 60,
+            "movespeed": 325,
+            "armor": 23.384,
+            "armorperlevel": 3.8,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 550,
+            "hpregen": 2.5,
+            "hpregenperlevel": 0.5,
+            "mpregen": 11.5,
+            "mpregenperlevel": 0.4,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 50.04,
+            "attackdamageperlevel": 3,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 2.14
+          }
+        },
+        "Swain": {
+          "version": "6.22.1",
+          "id": "Swain",
+          "key": "50",
+          "name": "Swain",
+          "title": "the Master Tactician",
+          "blurb": "The earliest account of Swain's existence comes from a Noxian infirmary doctor's notes. According to them, Swain limped into the ward without cry or complaint; his right leg was snapped in half, with bone protruding from the skin. A small, scowling ...",
+          "info": {
+            "attack": 2,
+            "defense": 6,
+            "magic": 9,
+            "difficulty": 8
+          },
+          "image": {
+            "full": "Swain.png",
+            "sprite": "champion3.png",
+            "group": "champion",
+            "x": 384,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Mage",
+            "Fighter"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 516.04,
+            "hpperlevel": 90,
+            "mp": 374,
+            "mpperlevel": 47,
+            "movespeed": 335,
+            "armor": 22.72,
+            "armorperlevel": 4,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 500,
+            "hpregen": 7.84,
+            "hpregenperlevel": 0.65,
+            "mpregen": 6,
+            "mpregenperlevel": 0.8,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 52.04,
+            "attackdamageperlevel": 3,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 2.11
+          }
+        },
+        "Syndra": {
+          "version": "6.22.1",
+          "id": "Syndra",
+          "key": "134",
+          "name": "Syndra",
+          "title": "the Dark Sovereign",
+          "blurb": "Born with immense magical potential, Syndra loves nothing more than exercising the incredible power at her command. With each passing day, her mastery of magical force grows more potent and devastating. Refusing any notion of balance or restraint, ...",
+          "info": {
+            "attack": 2,
+            "defense": 3,
+            "magic": 9,
+            "difficulty": 8
+          },
+          "image": {
+            "full": "Syndra.png",
+            "sprite": "champion3.png",
+            "group": "champion",
+            "x": 432,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Mage",
+            "Support"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 511.04,
+            "hpperlevel": 78,
+            "mp": 384,
+            "mpperlevel": 60,
+            "movespeed": 330,
+            "armor": 24.712,
+            "armorperlevel": 3.4,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 550,
+            "hpregen": 6.505,
+            "hpregenperlevel": 0.6,
+            "mpregen": 6,
+            "mpregenperlevel": 0.8,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 53.872,
+            "attackdamageperlevel": 2.9,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 2
+          }
+        },
+        "TahmKench": {
+          "version": "6.22.1",
+          "id": "TahmKench",
+          "key": "223",
+          "name": "Tahm Kench",
+          "title": "the River King",
+          "blurb": "''The whole world's a river, and I'm its king.''<br>Tahm Kench travels Runeterra's waterways, feeding his insatiable appetite with the misery of the unsuspecting. The singularly charming gourmand savors every moment of his victims' suffering.  A deal ...",
+          "info": {
+            "attack": 3,
+            "defense": 9,
+            "magic": 6,
+            "difficulty": 5
+          },
+          "image": {
+            "full": "TahmKench.png",
+            "sprite": "champion3.png",
+            "group": "champion",
+            "x": 0,
+            "y": 48,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Support",
+            "Tank"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 610,
+            "hpperlevel": 95,
+            "mp": 325,
+            "mpperlevel": 40,
+            "movespeed": 335,
+            "armor": 27,
+            "armorperlevel": 3.5,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 175,
+            "hpregen": 6.5,
+            "hpregenperlevel": 0.55,
+            "mpregen": 8,
+            "mpregenperlevel": 1,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 56,
+            "attackdamageperlevel": 3.2,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 2.5
+          }
+        },
+        "Taliyah": {
+          "version": "6.22.1",
+          "id": "Taliyah",
+          "key": "163",
+          "name": "Taliyah",
+          "title": "the Stoneweaver",
+          "blurb": "Taliyah is a nomadic mage from Shurima who weaves stone with energetic enthusiasm and raw determination. Torn between teenage wonder and adult responsibility, she has crossed nearly all of Valoran on a journey to learn the true nature of her growing ...",
+          "info": {
+            "attack": 1,
+            "defense": 7,
+            "magic": 8,
+            "difficulty": 5
+          },
+          "image": {
+            "full": "Taliyah.png",
+            "sprite": "champion3.png",
+            "group": "champion",
+            "x": 48,
+            "y": 48,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Mage",
+            "Support"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 520,
+            "hpperlevel": 75,
+            "mp": 340,
+            "mpperlevel": 60,
+            "movespeed": 325,
+            "armor": 20,
+            "armorperlevel": 3,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 525,
+            "hpregen": 7,
+            "hpregenperlevel": 0.7,
+            "mpregen": 7,
+            "mpregenperlevel": 0.85,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 56,
+            "attackdamageperlevel": 3.3,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 1.36
+          }
+        },
+        "Talon": {
+          "version": "6.22.1",
+          "id": "Talon",
+          "key": "91",
+          "name": "Talon",
+          "title": "the Blade's Shadow",
+          "blurb": "''The three deadliest blademasters in all of Valoran are bound to the house of Du Couteau: my father, myself, and Talon. Challenge us, if you dare.''<br>-- Katarina Du Couteau<br><br>Talon's earliest memories are the darkness of Noxus' underground ...",
+          "info": {
+            "attack": 9,
+            "defense": 3,
+            "magic": 1,
+            "difficulty": 7
+          },
+          "image": {
+            "full": "Talon.png",
+            "sprite": "champion3.png",
+            "group": "champion",
+            "x": 96,
+            "y": 48,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Assassin",
+            "Fighter"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 583,
+            "hpperlevel": 90,
+            "mp": 377.2,
+            "mpperlevel": 37,
+            "movespeed": 335,
+            "armor": 26.88,
+            "armorperlevel": 3.5,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 8.51,
+            "hpregenperlevel": 0.75,
+            "mpregen": 7.59,
+            "mpregenperlevel": 0.5,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 60,
+            "attackdamageperlevel": 3.1,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 2.9
+          }
+        },
+        "Taric": {
+          "version": "6.22.1",
+          "id": "Taric",
+          "key": "44",
+          "name": "Taric",
+          "title": "the Shield of Valoran",
+          "blurb": "''The best weapons are beautiful.''<br><br>Taric is the Aspect of the Protector, wielding incredible power as Runeterra's guardian of life, love, and beauty. Shamed by a dereliction of duty and exiled from his homeland Demacia, Taric ascended Mount ...",
+          "info": {
+            "attack": 4,
+            "defense": 8,
+            "magic": 5,
+            "difficulty": 3
+          },
+          "image": {
+            "full": "Taric.png",
+            "sprite": "champion3.png",
+            "group": "champion",
+            "x": 144,
+            "y": 48,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Support",
+            "Fighter"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 575,
+            "hpperlevel": 90,
+            "mp": 300,
+            "mpperlevel": 60,
+            "movespeed": 340,
+            "armor": 25,
+            "armorperlevel": 3.4,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 150,
+            "hpregen": 6,
+            "hpregenperlevel": 0.5,
+            "mpregen": 5,
+            "mpregenperlevel": 1,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 55,
+            "attackdamageperlevel": 3.5,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 2
+          }
+        },
+        "Teemo": {
+          "version": "6.22.1",
+          "id": "Teemo",
+          "key": "17",
+          "name": "Teemo",
+          "title": "the Swift Scout",
+          "blurb": "Teemo is a legend among his yordle brothers and sisters in Bandle City. As far as yordles are concerned, there is something just slightly off about him. While Teemo enjoys the companionship of other yordles, he also insists on frequent solo missions ...",
+          "info": {
+            "attack": 5,
+            "defense": 3,
+            "magic": 7,
+            "difficulty": 6
+          },
+          "image": {
+            "full": "Teemo.png",
+            "sprite": "champion3.png",
+            "group": "champion",
+            "x": 192,
+            "y": 48,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Marksman",
+            "Assassin"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 515.76,
+            "hpperlevel": 82,
+            "mp": 267.2,
+            "mpperlevel": 40,
+            "movespeed": 330,
+            "armor": 24.3,
+            "armorperlevel": 3.75,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 500,
+            "hpregen": 5.74,
+            "hpregenperlevel": 0.65,
+            "mpregen": 7.205,
+            "mpregenperlevel": 0.45,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 49.54,
+            "attackdamageperlevel": 3,
+            "attackspeedoffset": -0.0947,
+            "attackspeedperlevel": 3.38
+          }
+        },
+        "Thresh": {
+          "version": "6.22.1",
+          "id": "Thresh",
+          "key": "412",
+          "name": "Thresh",
+          "title": "the Chain Warden",
+          "blurb": "''The mind is a wondrous thing to tear apart.''<br><br>Sadistic and cunning, Thresh is a restless spirit who prides himself on tormenting mortals and breaking them with slow, excruciating inventiveness. His victims suffer far beyond the point of death,...",
+          "info": {
+            "attack": 5,
+            "defense": 6,
+            "magic": 6,
+            "difficulty": 7
+          },
+          "image": {
+            "full": "Thresh.png",
+            "sprite": "champion3.png",
+            "group": "champion",
+            "x": 240,
+            "y": 48,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Support",
+            "Fighter"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 560.52,
+            "hpperlevel": 93,
+            "mp": 273.92,
+            "mpperlevel": 44,
+            "movespeed": 335,
+            "armor": 16,
+            "armorperlevel": 0,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 450,
+            "hpregen": 6.92,
+            "hpregenperlevel": 0.55,
+            "mpregen": 6,
+            "mpregenperlevel": 0.8,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 47.696,
+            "attackdamageperlevel": 2.2,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 3.5
+          }
+        },
+        "Tristana": {
+          "version": "6.22.1",
+          "id": "Tristana",
+          "key": "18",
+          "name": "Tristana",
+          "title": "the Yordle Gunner",
+          "blurb": "Greatness comes in all shapes and sizes, as proven by this diminutive, cannon-wielding yordle. In a world fraught with turmoil, Tristana refuses to back down from any challenge. She represents the pinnacle of martial proficiency, unwavering courage, ...",
+          "info": {
+            "attack": 9,
+            "defense": 3,
+            "magic": 5,
+            "difficulty": 4
+          },
+          "image": {
+            "full": "Tristana.png",
+            "sprite": "champion3.png",
+            "group": "champion",
+            "x": 288,
+            "y": 48,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Marksman",
+            "Assassin"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 542.76,
+            "hpperlevel": 82,
+            "mp": 246.76,
+            "mpperlevel": 32,
+            "movespeed": 325,
+            "armor": 22,
+            "armorperlevel": 3,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 550,
+            "hpregen": 6.19,
+            "hpregenperlevel": 0.65,
+            "mpregen": 7.205,
+            "mpregenperlevel": 0.45,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 56.96,
+            "attackdamageperlevel": 2.41,
+            "attackspeedoffset": -0.04734,
+            "attackspeedperlevel": 1.5
+          }
+        },
+        "Trundle": {
+          "version": "6.22.1",
+          "id": "Trundle",
+          "key": "48",
+          "name": "Trundle",
+          "title": "the Troll King",
+          "blurb": "Trundle is a hulking and devious troll with a mischievous streak. There is nothing he can't beat into submission and bend to his will, not even the ice itself. With his massive, frozen club, he chills his enemies to the core and runs them through with ...",
+          "info": {
+            "attack": 7,
+            "defense": 6,
+            "magic": 2,
+            "difficulty": 5
+          },
+          "image": {
+            "full": "Trundle.png",
+            "sprite": "champion3.png",
+            "group": "champion",
+            "x": 336,
+            "y": 48,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Fighter",
+            "Tank"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 616.28,
+            "hpperlevel": 96,
+            "mp": 281.6,
+            "mpperlevel": 45,
+            "movespeed": 350,
+            "armor": 27.536,
+            "armorperlevel": 2.7,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 175,
+            "hpregen": 6,
+            "hpregenperlevel": 0.75,
+            "mpregen": 7.505,
+            "mpregenperlevel": 0.6,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 60.04,
+            "attackdamageperlevel": 3,
+            "attackspeedoffset": -0.0672,
+            "attackspeedperlevel": 2.9
+          }
+        },
+        "Tryndamere": {
+          "version": "6.22.1",
+          "id": "Tryndamere",
+          "key": "23",
+          "name": "Tryndamere",
+          "title": "the Barbarian King",
+          "blurb": "Fueled by his unbridled fury and rage, Tryndamere cuts his way through the tundra, mastering the art of battle by challenging the Freljord's greatest warriors. The wrathful barbarian seeks revenge on the one who decimated his clan and strikes down all ...",
+          "info": {
+            "attack": 10,
+            "defense": 5,
+            "magic": 2,
+            "difficulty": 5
+          },
+          "image": {
+            "full": "Tryndamere.png",
+            "sprite": "champion3.png",
+            "group": "champion",
+            "x": 384,
+            "y": 48,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Fighter",
+            "Assassin"
+          ],
+          "partype": "Battlefury",
+          "stats": {
+            "hp": 625.64,
+            "hpperlevel": 98,
+            "mp": 100,
+            "mpperlevel": 0,
+            "movespeed": 345,
+            "armor": 24.108,
+            "armorperlevel": 3.1,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 8.51,
+            "hpregenperlevel": 0.9,
+            "mpregen": 0,
+            "mpregenperlevel": 0,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 61.376,
+            "attackdamageperlevel": 3.2,
+            "attackspeedoffset": -0.0672,
+            "attackspeedperlevel": 2.9
+          }
+        },
+        "TwistedFate": {
+          "version": "6.22.1",
+          "id": "TwistedFate",
+          "key": "4",
+          "name": "Twisted Fate",
+          "title": "the Card Master",
+          "blurb": "Twisted Fate is an infamous card sharp and swindler who has gambled and charmed his way across much of the known world, earning the enmity and admiration of the rich and foolish alike. He rarely takes things seriously, greeting each day with a mocking ...",
+          "info": {
+            "attack": 6,
+            "defense": 2,
+            "magic": 6,
+            "difficulty": 9
+          },
+          "image": {
+            "full": "TwistedFate.png",
+            "sprite": "champion3.png",
+            "group": "champion",
+            "x": 432,
+            "y": 48,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Mage"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 521.76,
+            "hpperlevel": 82,
+            "mp": 265.84,
+            "mpperlevel": 38,
+            "movespeed": 330,
+            "armor": 20.542,
+            "armorperlevel": 3.15,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 525,
+            "hpregen": 5.505,
+            "hpregenperlevel": 0.6,
+            "mpregen": 6,
+            "mpregenperlevel": 0.8,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 49.954,
+            "attackdamageperlevel": 3.3,
+            "attackspeedoffset": -0.04,
+            "attackspeedperlevel": 3.22
+          }
+        },
+        "Twitch": {
+          "version": "6.22.1",
+          "id": "Twitch",
+          "key": "29",
+          "name": "Twitch",
+          "title": "the Plague Rat",
+          "blurb": "H.I.V.E. Incident Report<br>Code Violation: Industrial Homicide<br>Casefile Status: Unsolved<br>Investigating Agent: Rol, P.<br><br>Team responded to report of suspicious character, criminal activity; proceeded to Sump Works, Sector 90TZ. Sector 90TZ ...",
+          "info": {
+            "attack": 9,
+            "defense": 2,
+            "magic": 3,
+            "difficulty": 6
+          },
+          "image": {
+            "full": "Twitch.png",
+            "sprite": "champion3.png",
+            "group": "champion",
+            "x": 0,
+            "y": 96,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Marksman",
+            "Assassin"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 525.08,
+            "hpperlevel": 81,
+            "mp": 287.2,
+            "mpperlevel": 40,
+            "movespeed": 330,
+            "armor": 23.04,
+            "armorperlevel": 3,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 550,
+            "hpregen": 6.005,
+            "hpregenperlevel": 0.6,
+            "mpregen": 7.255,
+            "mpregenperlevel": 0.45,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 55.46,
+            "attackdamageperlevel": 2.41,
+            "attackspeedoffset": -0.08,
+            "attackspeedperlevel": 3.38
+          }
+        },
+        "Udyr": {
+          "version": "6.22.1",
+          "id": "Udyr",
+          "key": "77",
+          "name": "Udyr",
+          "title": "the Spirit Walker",
+          "blurb": "Udyr is more than a man; he is a vessel for the untamed power of four primal animal spirits. When tapping into the spirits' bestial natures, Udyr can harness their unique strengths: the tiger grants him speed and ferocity, the turtle resilience, the ...",
+          "info": {
+            "attack": 8,
+            "defense": 7,
+            "magic": 4,
+            "difficulty": 7
+          },
+          "image": {
+            "full": "Udyr.png",
+            "sprite": "champion3.png",
+            "group": "champion",
+            "x": 48,
+            "y": 96,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Fighter",
+            "Tank"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 593.32,
+            "hpperlevel": 99,
+            "mp": 270.4,
+            "mpperlevel": 30,
+            "movespeed": 345,
+            "armor": 25.47,
+            "armorperlevel": 4,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 6,
+            "hpregenperlevel": 0.75,
+            "mpregen": 7.505,
+            "mpregenperlevel": 0.45,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 58.286,
+            "attackdamageperlevel": 3.2,
+            "attackspeedoffset": -0.05,
+            "attackspeedperlevel": 2.67
+          }
+        },
+        "Urgot": {
+          "version": "6.22.1",
+          "id": "Urgot",
+          "key": "6",
+          "name": "Urgot",
+          "title": "the Headsman's Pride",
+          "blurb": "There are warriors who become great for their strength, cunning, or skill with arms. Others simply refuse to die. Urgot, once a great soldier of Noxus, may constitute a case in support of the latter. Prone to diving headlong into enemy battle lines, ...",
+          "info": {
+            "attack": 8,
+            "defense": 5,
+            "magic": 3,
+            "difficulty": 8
+          },
+          "image": {
+            "full": "Urgot.png",
+            "sprite": "champion3.png",
+            "group": "champion",
+            "x": 96,
+            "y": 96,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Marksman",
+            "Fighter"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 586.52,
+            "hpperlevel": 89,
+            "mp": 312.4,
+            "mpperlevel": 55,
+            "movespeed": 335,
+            "armor": 24.544,
+            "armorperlevel": 3.3,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 425,
+            "hpregen": 6.505,
+            "hpregenperlevel": 0.6,
+            "mpregen": 8.59,
+            "mpregenperlevel": 0.65,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 54.05,
+            "attackdamageperlevel": 3.6,
+            "attackspeedoffset": -0.03,
+            "attackspeedperlevel": 2.9
+          }
+        },
+        "Varus": {
+          "version": "6.22.1",
+          "id": "Varus",
+          "key": "110",
+          "name": "Varus",
+          "title": "the Arrow of Retribution",
+          "blurb": "''The life of an arrow is fleeting, built of nothing but direction and intent.''<br><br>For his incomparable skill with the bow and his unquestioned sense of honor, Varus was chosen to be the warden of a sacred Ionian temple. The temple was built to ...",
+          "info": {
+            "attack": 7,
+            "defense": 3,
+            "magic": 4,
+            "difficulty": 2
+          },
+          "image": {
+            "full": "Varus.png",
+            "sprite": "champion3.png",
+            "group": "champion",
+            "x": 144,
+            "y": 96,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Marksman",
+            "Mage"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 537.76,
+            "hpperlevel": 82,
+            "mp": 360.48,
+            "mpperlevel": 33,
+            "movespeed": 330,
+            "armor": 23.212,
+            "armorperlevel": 3.4,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 575,
+            "hpregen": 5.42,
+            "hpregenperlevel": 0.55,
+            "mpregen": 7.34,
+            "mpregenperlevel": 0.8,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 54.66,
+            "attackdamageperlevel": 2.41,
+            "attackspeedoffset": -0.05,
+            "attackspeedperlevel": 3
+          }
+        },
+        "Vayne": {
+          "version": "6.22.1",
+          "id": "Vayne",
+          "key": "67",
+          "name": "Vayne",
+          "title": "the Night Hunter",
+          "blurb": "The world is not always as civilized as people might think. There are still those who would follow the blackest paths of magic and become corrupted by the darker powers that flow through Runeterra. Shauna Vayne knows this fact well.<br><br>As a young ...",
+          "info": {
+            "attack": 10,
+            "defense": 1,
+            "magic": 1,
+            "difficulty": 8
+          },
+          "image": {
+            "full": "Vayne.png",
+            "sprite": "champion3.png",
+            "group": "champion",
+            "x": 192,
+            "y": 96,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Marksman",
+            "Assassin"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 498.44,
+            "hpperlevel": 83,
+            "mp": 231.8,
+            "mpperlevel": 35,
+            "movespeed": 330,
+            "armor": 19.012,
+            "armorperlevel": 3.4,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 550,
+            "hpregen": 5.42,
+            "hpregenperlevel": 0.55,
+            "mpregen": 6.97,
+            "mpregenperlevel": 0.4,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 55.88,
+            "attackdamageperlevel": 1.66,
+            "attackspeedoffset": -0.05,
+            "attackspeedperlevel": 4
+          }
+        },
+        "Veigar": {
+          "version": "6.22.1",
+          "id": "Veigar",
+          "key": "45",
+          "name": "Veigar",
+          "title": "the Tiny Master of Evil",
+          "blurb": "To most, thoughts of yordles do not conjure images to be feared. The easygoing half-pint race, though fierce, is often regarded with some degree of joviality. Their high-pitched voices and naturally cute forms inspire something of a protective ...",
+          "info": {
+            "attack": 2,
+            "defense": 2,
+            "magic": 10,
+            "difficulty": 7
+          },
+          "image": {
+            "full": "Veigar.png",
+            "sprite": "champion3.png",
+            "group": "champion",
+            "x": 240,
+            "y": 96,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Mage"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 492.76,
+            "hpperlevel": 82,
+            "mp": 392.4,
+            "mpperlevel": 52,
+            "movespeed": 340,
+            "armor": 22.55,
+            "armorperlevel": 3.75,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 525,
+            "hpregen": 5.42,
+            "hpregenperlevel": 0.55,
+            "mpregen": 6,
+            "mpregenperlevel": 0.8,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 50.71,
+            "attackdamageperlevel": 2.625,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 2.24
+          }
+        },
+        "Velkoz": {
+          "version": "6.22.1",
+          "id": "Velkoz",
+          "key": "161",
+          "name": "Vel'Koz",
+          "title": "the Eye of the Void",
+          "blurb": "I pass into the sudden glare. Blink. Blink, blink, blink. My eyes adjust and evaluate the landscape before me.<br><br>There's a scurrying. I look down to find a small, white creature standing on its hind legs, sniffing at my body. It intrigues me....",
+          "info": {
+            "attack": 2,
+            "defense": 2,
+            "magic": 10,
+            "difficulty": 8
+          },
+          "image": {
+            "full": "Velkoz.png",
+            "sprite": "champion3.png",
+            "group": "champion",
+            "x": 288,
+            "y": 96,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Mage"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 507.68,
+            "hpperlevel": 76,
+            "mp": 375.6,
+            "mpperlevel": 42,
+            "movespeed": 340,
+            "armor": 21.88,
+            "armorperlevel": 3.5,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 525,
+            "hpregen": 5.42,
+            "hpregenperlevel": 0.55,
+            "mpregen": 6,
+            "mpregenperlevel": 0.8,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 54.9379,
+            "attackdamageperlevel": 3.14159,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 1.36
+          }
+        },
+        "Vi": {
+          "version": "6.22.1",
+          "id": "Vi",
+          "key": "254",
+          "name": "Vi",
+          "title": "the Piltover Enforcer",
+          "blurb": "To Vi, every problem is just another brick wall to punch through with her gigantic hextech gauntlets. Though she grew up on the wrong side of the law, Vi now uses her criminal know-how to serve Piltover's police force. Vi's brash attitude, abrasive ...",
+          "info": {
+            "attack": 8,
+            "defense": 5,
+            "magic": 3,
+            "difficulty": 4
+          },
+          "image": {
+            "full": "Vi.png",
+            "sprite": "champion3.png",
+            "group": "champion",
+            "x": 336,
+            "y": 96,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Fighter",
+            "Assassin"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 582.8,
+            "hpperlevel": 85,
+            "mp": 295.6,
+            "mpperlevel": 45,
+            "movespeed": 345,
+            "armor": 25.88,
+            "armorperlevel": 3.5,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 9.01,
+            "hpregenperlevel": 0.9,
+            "mpregen": 8.09,
+            "mpregenperlevel": 0.65,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 55.88,
+            "attackdamageperlevel": 3.5,
+            "attackspeedoffset": -0.03,
+            "attackspeedperlevel": 2.5
+          }
+        },
+        "Viktor": {
+          "version": "6.22.1",
+          "id": "Viktor",
+          "key": "112",
+          "name": "Viktor",
+          "title": "the Machine Herald",
+          "blurb": "Early in life, Viktor discovered his passion for science and invention, particularly in the field of mechanical automation. He attended Zaun's prestigious College of Techmaturgy and led the team that constructed Blitzcrank - a scientific breakthrough ...",
+          "info": {
+            "attack": 2,
+            "defense": 4,
+            "magic": 10,
+            "difficulty": 9
+          },
+          "image": {
+            "full": "Viktor.png",
+            "sprite": "champion3.png",
+            "group": "champion",
+            "x": 384,
+            "y": 96,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Mage"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 516.04,
+            "hpperlevel": 78,
+            "mp": 324,
+            "mpperlevel": 50,
+            "movespeed": 335,
+            "armor": 22.72,
+            "armorperlevel": 4,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 525,
+            "hpregen": 7.84,
+            "hpregenperlevel": 0.65,
+            "mpregen": 6,
+            "mpregenperlevel": 0.8,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 52.04,
+            "attackdamageperlevel": 3,
+            "attackspeedoffset": -0.05,
+            "attackspeedperlevel": 2.11
+          }
+        },
+        "Vladimir": {
+          "version": "6.22.1",
+          "id": "Vladimir",
+          "key": "8",
+          "name": "Vladimir",
+          "title": "the Crimson Reaper",
+          "blurb": "There is a temple hidden in the mountains between Noxus and the Tempest Flats, where the secrets of an ancient and terrifying sorcery are kept. The area surrounding the temple is littered with the exsanguinated corpses of those who have mistakenly ...",
+          "info": {
+            "attack": 2,
+            "defense": 6,
+            "magic": 8,
+            "difficulty": 7
+          },
+          "image": {
+            "full": "Vladimir.png",
+            "sprite": "champion3.png",
+            "group": "champion",
+            "x": 432,
+            "y": 96,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Mage",
+            "Tank"
+          ],
+          "partype": "Gnarfury",
+          "stats": {
+            "hp": 525,
+            "hpperlevel": 84,
+            "mp": 2,
+            "mpperlevel": 0,
+            "movespeed": 330,
+            "armor": 23,
+            "armorperlevel": 3.3,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 450,
+            "hpregen": 7.005,
+            "hpregenperlevel": 0.6,
+            "mpregen": 0,
+            "mpregenperlevel": 0,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 52,
+            "attackdamageperlevel": 3,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 2
+          }
+        },
+        "Volibear": {
+          "version": "6.22.1",
+          "id": "Volibear",
+          "key": "106",
+          "name": "Volibear",
+          "title": "the Thunder's Roar",
+          "blurb": "The unforgiving northern reaches of the Freljord are home to the Ursine, a fierce and warlike race that has endured the barren tundra for thousands of years. Their leader is a furious adversary who commands the force of lightning to strike fear within ...",
+          "info": {
+            "attack": 7,
+            "defense": 7,
+            "magic": 4,
+            "difficulty": 3
+          },
+          "image": {
+            "full": "Volibear.png",
+            "sprite": "champion4.png",
+            "group": "champion",
+            "x": 0,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Fighter",
+            "Tank"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 584.48,
+            "hpperlevel": 86,
+            "mp": 270.4,
+            "mpperlevel": 30,
+            "movespeed": 345,
+            "armor": 26.38,
+            "armorperlevel": 3.5,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 8.09,
+            "hpregenperlevel": 0.65,
+            "mpregen": 8.09,
+            "mpregenperlevel": 0.65,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 59.544,
+            "attackdamageperlevel": 3.3,
+            "attackspeedoffset": -0.05,
+            "attackspeedperlevel": 2.67
+          }
+        },
+        "Warwick": {
+          "version": "6.22.1",
+          "id": "Warwick",
+          "key": "19",
+          "name": "Warwick",
+          "title": "the Blood Hunter",
+          "blurb": "Warwick was once a man revered for his ability to track down human specimens for the darkest types of scientific research. When his ambitions exceeded his physical limits, he drank a dangerous elixir to transform himself into an unstoppable manhunter. ...",
+          "info": {
+            "attack": 7,
+            "defense": 4,
+            "magic": 4,
+            "difficulty": 3
+          },
+          "image": {
+            "full": "Warwick.png",
+            "sprite": "champion4.png",
+            "group": "champion",
+            "x": 48,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Fighter",
+            "Tank"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 592.64,
+            "hpperlevel": 98,
+            "mp": 240.4,
+            "mpperlevel": 30,
+            "movespeed": 345,
+            "armor": 25.88,
+            "armorperlevel": 3.5,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 8.39,
+            "hpregenperlevel": 0.8,
+            "mpregen": 8.105,
+            "mpregenperlevel": 0.6,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 62.43,
+            "attackdamageperlevel": 3.375,
+            "attackspeedoffset": -0.08,
+            "attackspeedperlevel": 2.88
+          }
+        },
+        "Xerath": {
+          "version": "6.22.1",
+          "id": "Xerath",
+          "key": "101",
+          "name": "Xerath",
+          "title": "the Magus Ascendant",
+          "blurb": "''A lifetime as a slave has prepared me for eternity as your master.''<br><br>Xerath is an Ascended Magus of ancient Shurima, a being of arcane energy writhing in the broken shards of a magical sarcophagus. For millennia, he was trapped beneath the ...",
+          "info": {
+            "attack": 1,
+            "defense": 3,
+            "magic": 10,
+            "difficulty": 8
+          },
+          "image": {
+            "full": "Xerath.png",
+            "sprite": "champion4.png",
+            "group": "champion",
+            "x": 96,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Mage",
+            "Assassin"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 514.4,
+            "hpperlevel": 80,
+            "mp": 366.96,
+            "mpperlevel": 44,
+            "movespeed": 340,
+            "armor": 21.88,
+            "armorperlevel": 3.5,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 525,
+            "hpregen": 5.42,
+            "hpregenperlevel": 0.55,
+            "mpregen": 6,
+            "mpregenperlevel": 0.8,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 54.7,
+            "attackdamageperlevel": 3,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 1.36
+          }
+        },
+        "XinZhao": {
+          "version": "6.22.1",
+          "id": "XinZhao",
+          "key": "5",
+          "name": "Xin Zhao",
+          "title": "the Seneschal of Demacia",
+          "blurb": "''Death is inevitable, one can only avoid defeat.''<br><br>Whenever Jarvan III, the king of Demacia, delivers one of his rallying speeches from the glinting marble balcony atop the Royal Palace, Xin Zhao is at his side. Coined the Seneschal of Demacia,...",
+          "info": {
+            "attack": 8,
+            "defense": 6,
+            "magic": 3,
+            "difficulty": 2
+          },
+          "image": {
+            "full": "XinZhao.png",
+            "sprite": "champion4.png",
+            "group": "champion",
+            "x": 144,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Fighter",
+            "Assassin"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 600,
+            "hpperlevel": 92,
+            "mp": 273.8,
+            "mpperlevel": 35,
+            "movespeed": 345,
+            "armor": 25.88,
+            "armorperlevel": 3.5,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 175,
+            "hpregen": 8.175,
+            "hpregenperlevel": 0.7,
+            "mpregen": 7.255,
+            "mpregenperlevel": 0.45,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 57.544,
+            "attackdamageperlevel": 3.3,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 2.6
+          }
+        },
+        "Yasuo": {
+          "version": "6.22.1",
+          "id": "Yasuo",
+          "key": "157",
+          "name": "Yasuo",
+          "title": "the Unforgiven",
+          "blurb": "Yasuo is a man of resolve, an agile swordsman who wields the wind itself to cut down his foes. This once-proud warrior has been disgraced by a false accusation and forced into a desperate fight for survival. With the world turned against him, he will ...",
+          "info": {
+            "attack": 8,
+            "defense": 4,
+            "magic": 4,
+            "difficulty": 10
+          },
+          "image": {
+            "full": "Yasuo.png",
+            "sprite": "champion4.png",
+            "group": "champion",
+            "x": 192,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Fighter",
+            "Assassin"
+          ],
+          "partype": "Wind",
+          "stats": {
+            "hp": 517.76,
+            "hpperlevel": 82,
+            "mp": 100,
+            "mpperlevel": 0,
+            "movespeed": 345,
+            "armor": 24.712,
+            "armorperlevel": 3.4,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 175,
+            "hpregen": 6.51,
+            "hpregenperlevel": 0.9,
+            "mpregen": 0,
+            "mpregenperlevel": 0,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 55.376,
+            "attackdamageperlevel": 3.2,
+            "attackspeedoffset": -0.067,
+            "attackspeedperlevel": 2.5
+          }
+        },
+        "Yorick": {
+          "version": "6.22.1",
+          "id": "Yorick",
+          "key": "83",
+          "name": "Yorick",
+          "title": "Shepherd of Souls",
+          "blurb": "''These isles… How they scream.''<br>The last survivor of a long-forgotten religious order, Yorick is both blessed and cursed with power over the dead. Trapped on the Shadow Isles, his only companions are the rotting corpses and shrieking spirits that ...",
+          "info": {
+            "attack": 6,
+            "defense": 6,
+            "magic": 4,
+            "difficulty": 6
+          },
+          "image": {
+            "full": "Yorick.png",
+            "sprite": "champion4.png",
+            "group": "champion",
+            "x": 240,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Fighter",
+            "Tank"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 580,
+            "hpperlevel": 100,
+            "mp": 300,
+            "mpperlevel": 40,
+            "movespeed": 340,
+            "armor": 30,
+            "armorperlevel": 4,
+            "spellblock": 32,
+            "spellblockperlevel": 1.25,
+            "attackrange": 175,
+            "hpregen": 8,
+            "hpregenperlevel": 0.8,
+            "mpregen": 7.5,
+            "mpregenperlevel": 0.75,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 57,
+            "attackdamageperlevel": 5,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 2
+          }
+        },
+        "Zac": {
+          "version": "6.22.1",
+          "id": "Zac",
+          "key": "154",
+          "name": "Zac",
+          "title": "the Secret Weapon",
+          "blurb": "Zac is the product of a Zaun experiment to manufacture a hexchem-engineered supersoldier - the Zaun Amorphous Combatant. Combining brute strength with limitless flexibility, he is a versatile juggernaut: a creative fighter who bounces over obstacles ...",
+          "info": {
+            "attack": 3,
+            "defense": 7,
+            "magic": 7,
+            "difficulty": 8
+          },
+          "image": {
+            "full": "Zac.png",
+            "sprite": "champion4.png",
+            "group": "champion",
+            "x": 288,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Tank",
+            "Fighter"
+          ],
+          "partype": "None",
+          "stats": {
+            "hp": 614.6,
+            "hpperlevel": 95,
+            "mp": 0,
+            "mpperlevel": 0,
+            "movespeed": 340,
+            "armor": 23.88,
+            "armorperlevel": 3.5,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 175,
+            "hpregen": 7.92,
+            "hpregenperlevel": 0.55,
+            "mpregen": 0,
+            "mpregenperlevel": 0,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 59.67,
+            "attackdamageperlevel": 3.375,
+            "attackspeedoffset": -0.02,
+            "attackspeedperlevel": 1.6
+          }
+        },
+        "Zed": {
+          "version": "6.22.1",
+          "id": "Zed",
+          "key": "238",
+          "name": "Zed",
+          "title": "the Master of Shadows",
+          "blurb": "Zed is the first ninja in 200 years to unlock the ancient, forbidden ways. He defied his clan and master, casting off the balance and discipline that had shackled him all his life. Zed now offers power to those who embrace knowledge of the shadows, ...",
+          "info": {
+            "attack": 9,
+            "defense": 2,
+            "magic": 1,
+            "difficulty": 7
+          },
+          "image": {
+            "full": "Zed.png",
+            "sprite": "champion4.png",
+            "group": "champion",
+            "x": 336,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Assassin",
+            "Fighter"
+          ],
+          "partype": "Energy",
+          "stats": {
+            "hp": 579.4,
+            "hpperlevel": 80,
+            "mp": 200,
+            "mpperlevel": 0,
+            "movespeed": 345,
+            "armor": 26.88,
+            "armorperlevel": 3.5,
+            "spellblock": 32.1,
+            "spellblockperlevel": 1.25,
+            "attackrange": 125,
+            "hpregen": 7.09,
+            "hpregenperlevel": 0.65,
+            "mpregen": 50,
+            "mpregenperlevel": 0,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 54.712,
+            "attackdamageperlevel": 3.4,
+            "attackspeedoffset": -0.03,
+            "attackspeedperlevel": 2.1
+          }
+        },
+        "Ziggs": {
+          "version": "6.22.1",
+          "id": "Ziggs",
+          "key": "115",
+          "name": "Ziggs",
+          "title": "the Hexplosives Expert",
+          "blurb": "Ziggs was born with a talent for tinkering, but his chaotic, hyperactive nature was unusual among yordle scientists. Aspiring to be a revered inventor like Heimerdinger, he rattled through ambitious projects with manic zeal, emboldened by both his ...",
+          "info": {
+            "attack": 2,
+            "defense": 4,
+            "magic": 9,
+            "difficulty": 4
+          },
+          "image": {
+            "full": "Ziggs.png",
+            "sprite": "champion4.png",
+            "group": "champion",
+            "x": 384,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Mage"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 524.4,
+            "hpperlevel": 80,
+            "mp": 384,
+            "mpperlevel": 47,
+            "movespeed": 325,
+            "armor": 21.544,
+            "armorperlevel": 3.3,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 550,
+            "hpregen": 6.255,
+            "hpregenperlevel": 0.6,
+            "mpregen": 6,
+            "mpregenperlevel": 0.8,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 54.208,
+            "attackdamageperlevel": 3.1,
+            "attackspeedoffset": -0.04734,
+            "attackspeedperlevel": 2
+          }
+        },
+        "Zilean": {
+          "version": "6.22.1",
+          "id": "Zilean",
+          "key": "26",
+          "name": "Zilean",
+          "title": "the Chronokeeper",
+          "blurb": "In the wastelands of Urtistan, there was once a great city. It perished long ago in a terrible Rune War, like most of the lands below the Great Barrier. Nevertheless, one man survived: a sorcerer named Zilean. Being obsessed with time, it was only ...",
+          "info": {
+            "attack": 2,
+            "defense": 5,
+            "magic": 8,
+            "difficulty": 6
+          },
+          "image": {
+            "full": "Zilean.png",
+            "sprite": "champion4.png",
+            "group": "champion",
+            "x": 432,
+            "y": 0,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Support",
+            "Mage"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 499.28,
+            "hpperlevel": 77,
+            "mp": 360.8,
+            "mpperlevel": 60,
+            "movespeed": 335,
+            "armor": 19.134,
+            "armorperlevel": 3.8,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 550,
+            "hpregen": 5.44,
+            "hpregenperlevel": 0.5,
+            "mpregen": 8.5,
+            "mpregenperlevel": 0.8,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 51.64,
+            "attackdamageperlevel": 3,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 2.13
+          }
+        },
+        "Zyra": {
+          "version": "6.22.1",
+          "id": "Zyra",
+          "key": "143",
+          "name": "Zyra",
+          "title": "Rise of the Thorns",
+          "blurb": "Longing to take control of her fate, the ancient, dying plant Zyra transferred her consciousness into a human body for a second chance at life. Centuries ago, she and her kind dominated the Kumungu Jungle, using thorns and vines to consume any animal ...",
+          "info": {
+            "attack": 4,
+            "defense": 3,
+            "magic": 8,
+            "difficulty": 7
+          },
+          "image": {
+            "full": "Zyra.png",
+            "sprite": "champion4.png",
+            "group": "champion",
+            "x": 0,
+            "y": 48,
+            "w": 48,
+            "h": 48
+          },
+          "tags": [
+            "Mage",
+            "Support"
+          ],
+          "partype": "MP",
+          "stats": {
+            "hp": 499.32,
+            "hpperlevel": 74,
+            "mp": 334,
+            "mpperlevel": 50,
+            "movespeed": 340,
+            "armor": 20.04,
+            "armorperlevel": 3,
+            "spellblock": 30,
+            "spellblockperlevel": 0,
+            "attackrange": 575,
+            "hpregen": 5.69,
+            "hpregenperlevel": 0.5,
+            "mpregen": 8.5,
+            "mpregenperlevel": 0.8,
+            "crit": 0,
+            "critperlevel": 0,
+            "attackdamage": 53.376,
+            "attackdamageperlevel": 3.2,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 2.11
+          }
+        }
+      }
+    },
+    "headers": {
+      "content-type": "application/json",
+      "content-length": "126725",
+      "connection": "close",
+      "accept-ranges": "bytes",
+      "access-control-allow-origin": "*",
+      "cache-control": "max-age=315360000, public",
+      "date": "Fri, 04 Nov 2016 03:00:06 GMT",
+      "etag": "\"30bf3d-1ef05-5406e22348200\"",
+      "expires": "Thu, 31 Dec 2099 00:00:00 GMT",
+      "last-modified": "Thu, 03 Nov 2016 23:44:08 GMT",
+      "server": "Apache/2.2.29 (Amazon)",
+      "via": "1.1 varnish, 1.1 cb6a82ea93f5294918b0ddbd443a8dea.cloudfront.net (CloudFront)",
+      "x-varnish": "2423686877",
+      "age": "820498",
+      "x-cache": "Hit from cloudfront",
+      "x-amz-cf-id": "-zIX0sQHhQ119XWjqtJRptn8bAeeK_Y58hweAr5C9b4DGT1AkaA-zg=="
     }
   }
 ]

--- a/test/mocks/mocks/get__summoner_performance_should_fail_for_unknown_summoner.json
+++ b/test/mocks/mocks/get__summoner_performance_should_fail_for_unknown_summoner.json
@@ -7,21 +7,21 @@
     "status": 200,
     "response": {
       "n": {
-        "item": "6.21.1",
-        "rune": "6.21.1",
-        "mastery": "6.21.1",
-        "summoner": "6.21.1",
-        "champion": "6.21.1",
-        "profileicon": "6.21.1",
-        "map": "6.21.1",
-        "language": "6.21.1"
+        "item": "6.22.1",
+        "rune": "6.22.1",
+        "mastery": "6.22.1",
+        "summoner": "6.22.1",
+        "champion": "6.22.1",
+        "profileicon": "6.22.1",
+        "map": "6.22.1",
+        "language": "6.22.1"
       },
-      "v": "6.21.1",
+      "v": "6.22.1",
       "l": "en_GB",
       "cdn": "http://ddragon.leagueoflegends.com/cdn",
-      "dd": "6.21.1",
-      "lg": "6.21.1",
-      "css": "6.21.1",
+      "dd": "6.22.1",
+      "lg": "6.22.1",
+      "css": "6.22.1",
       "profileiconmax": 28,
       "store": null
     },
@@ -31,17 +31,17 @@
       "connection": "close",
       "accept-ranges": "bytes",
       "access-control-allow-origin": "*",
-      "age": "29",
+      "age": "406",
       "cache-control": "must-revalidate, no-cache, private",
-      "date": "Mon, 31 Oct 2016 18:16:54 GMT",
-      "etag": "\"89b376aa3d1ca56a0db73019ef158cc2\"",
+      "date": "Sun, 13 Nov 2016 14:45:43 GMT",
+      "etag": "\"b629bafa47432ff8c0555937d69dd18e\"",
       "server": "Apache/2.2.29 (Amazon)",
-      "via": "1.1 varnish, 1.1 5e0caf898a8e3ffa2e1768d5e217e977.cloudfront.net (CloudFront)",
-      "x-content-digest": "en0bb0db99ba6eaaeb0ba4bb7c1d898bf646f54351",
+      "via": "1.1 varnish, 1.1 f83e672bbba2e0ea3294355a57e2ae80.cloudfront.net (CloudFront)",
+      "x-content-digest": "enc240ea78e07b1e8b664f1ad5ff5349862f5dab90",
       "x-powered-by": "PHP/5.3.29",
-      "x-varnish": "2362085920 2362078172",
+      "x-varnish": "2602559113 2602449820",
       "x-cache": "Miss from cloudfront",
-      "x-amz-cf-id": "zLFPgVJ8vbKiqIqQyZK2FRh1LdOvZQ_SBhfIjqIz712omWTpwlOSNA=="
+      "x-amz-cf-id": "9UquHLFg4uoUTJDCClAbqpKRUgWyyP-HJ-3hOPT4zf5rEmZQSh264w=="
     }
   },
   {
@@ -58,7 +58,7 @@
     },
     "headers": {
       "content-type": "application/json;charset=utf-8",
-      "x-rate-limit-count": "223:10,3371:600",
+      "x-rate-limit-count": "304:10,17702:600",
       "content-length": "66",
       "connection": "Close"
     }
@@ -66,16 +66,16 @@
   {
     "scope": "https://ddragon.leagueoflegends.com:443",
     "method": "GET",
-    "path": "/cdn/6.21.1/data/en_US/champion.json",
+    "path": "/cdn/6.22.1/data/en_US/champion.json",
     "body": "",
     "status": 200,
     "response": {
       "type": "champion",
       "format": "standAloneComplex",
-      "version": "6.21.1",
+      "version": "6.22.1",
       "data": {
         "Aatrox": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Aatrox",
           "key": "266",
           "name": "Aatrox",
@@ -125,7 +125,7 @@
           }
         },
         "Ahri": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Ahri",
           "key": "103",
           "name": "Ahri",
@@ -175,7 +175,7 @@
           }
         },
         "Akali": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Akali",
           "key": "84",
           "name": "Akali",
@@ -224,7 +224,7 @@
           }
         },
         "Alistar": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Alistar",
           "key": "12",
           "name": "Alistar",
@@ -274,7 +274,7 @@
           }
         },
         "Amumu": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Amumu",
           "key": "32",
           "name": "Amumu",
@@ -324,7 +324,7 @@
           }
         },
         "Anivia": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Anivia",
           "key": "34",
           "name": "Anivia",
@@ -374,7 +374,7 @@
           }
         },
         "Annie": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Annie",
           "key": "1",
           "name": "Annie",
@@ -423,7 +423,7 @@
           }
         },
         "Ashe": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Ashe",
           "key": "22",
           "name": "Ashe",
@@ -473,7 +473,7 @@
           }
         },
         "AurelionSol": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "AurelionSol",
           "key": "136",
           "name": "Aurelion Sol",
@@ -523,7 +523,7 @@
           }
         },
         "Azir": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Azir",
           "key": "268",
           "name": "Azir",
@@ -573,7 +573,7 @@
           }
         },
         "Bard": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Bard",
           "key": "432",
           "name": "Bard",
@@ -623,7 +623,7 @@
           }
         },
         "Blitzcrank": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Blitzcrank",
           "key": "53",
           "name": "Blitzcrank",
@@ -673,7 +673,7 @@
           }
         },
         "Brand": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Brand",
           "key": "63",
           "name": "Brand",
@@ -722,7 +722,7 @@
           }
         },
         "Braum": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Braum",
           "key": "201",
           "name": "Braum",
@@ -772,7 +772,7 @@
           }
         },
         "Caitlyn": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Caitlyn",
           "key": "51",
           "name": "Caitlyn",
@@ -821,7 +821,7 @@
           }
         },
         "Cassiopeia": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Cassiopeia",
           "key": "69",
           "name": "Cassiopeia",
@@ -870,7 +870,7 @@
           }
         },
         "Chogath": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Chogath",
           "key": "31",
           "name": "Cho'Gath",
@@ -920,7 +920,7 @@
           }
         },
         "Corki": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Corki",
           "key": "42",
           "name": "Corki",
@@ -969,7 +969,7 @@
           }
         },
         "Darius": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Darius",
           "key": "122",
           "name": "Darius",
@@ -1019,7 +1019,7 @@
           }
         },
         "Diana": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Diana",
           "key": "131",
           "name": "Diana",
@@ -1069,7 +1069,7 @@
           }
         },
         "Draven": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Draven",
           "key": "119",
           "name": "Draven",
@@ -1118,7 +1118,7 @@
           }
         },
         "DrMundo": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "DrMundo",
           "key": "36",
           "name": "Dr. Mundo",
@@ -1168,7 +1168,7 @@
           }
         },
         "Ekko": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Ekko",
           "key": "245",
           "name": "Ekko",
@@ -1207,7 +1207,7 @@
             "attackrange": 125,
             "hpregen": 9,
             "hpregenperlevel": 0.9,
-            "mpregen": 6,
+            "mpregen": 7,
             "mpregenperlevel": 0.8,
             "crit": 0,
             "critperlevel": 0,
@@ -1218,7 +1218,7 @@
           }
         },
         "Elise": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Elise",
           "key": "60",
           "name": "Elise",
@@ -1268,7 +1268,7 @@
           }
         },
         "Evelynn": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Evelynn",
           "key": "28",
           "name": "Evelynn",
@@ -1318,7 +1318,7 @@
           }
         },
         "Ezreal": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Ezreal",
           "key": "81",
           "name": "Ezreal",
@@ -1368,7 +1368,7 @@
           }
         },
         "FiddleSticks": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "FiddleSticks",
           "key": "9",
           "name": "Fiddlesticks",
@@ -1418,7 +1418,7 @@
           }
         },
         "Fiora": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Fiora",
           "key": "114",
           "name": "Fiora",
@@ -1468,7 +1468,7 @@
           }
         },
         "Fizz": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Fizz",
           "key": "105",
           "name": "Fizz",
@@ -1518,7 +1518,7 @@
           }
         },
         "Galio": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Galio",
           "key": "3",
           "name": "Galio",
@@ -1568,7 +1568,7 @@
           }
         },
         "Gangplank": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Gangplank",
           "key": "41",
           "name": "Gangplank",
@@ -1617,7 +1617,7 @@
           }
         },
         "Garen": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Garen",
           "key": "86",
           "name": "Garen",
@@ -1667,7 +1667,7 @@
           }
         },
         "Gnar": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Gnar",
           "key": "150",
           "name": "Gnar",
@@ -1717,7 +1717,7 @@
           }
         },
         "Gragas": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Gragas",
           "key": "79",
           "name": "Gragas",
@@ -1767,7 +1767,7 @@
           }
         },
         "Graves": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Graves",
           "key": "104",
           "name": "Graves",
@@ -1816,7 +1816,7 @@
           }
         },
         "Hecarim": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Hecarim",
           "key": "120",
           "name": "Hecarim",
@@ -1866,7 +1866,7 @@
           }
         },
         "Heimerdinger": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Heimerdinger",
           "key": "74",
           "name": "Heimerdinger",
@@ -1916,7 +1916,7 @@
           }
         },
         "Illaoi": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Illaoi",
           "key": "420",
           "name": "Illaoi",
@@ -1966,7 +1966,7 @@
           }
         },
         "Irelia": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Irelia",
           "key": "39",
           "name": "Irelia",
@@ -2016,7 +2016,7 @@
           }
         },
         "Ivern": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Ivern",
           "key": "427",
           "name": "Ivern",
@@ -2066,7 +2066,7 @@
           }
         },
         "Janna": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Janna",
           "key": "40",
           "name": "Janna",
@@ -2116,7 +2116,7 @@
           }
         },
         "JarvanIV": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "JarvanIV",
           "key": "59",
           "name": "Jarvan IV",
@@ -2166,7 +2166,7 @@
           }
         },
         "Jax": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Jax",
           "key": "24",
           "name": "Jax",
@@ -2216,7 +2216,7 @@
           }
         },
         "Jayce": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Jayce",
           "key": "126",
           "name": "Jayce",
@@ -2266,7 +2266,7 @@
           }
         },
         "Jhin": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Jhin",
           "key": "202",
           "name": "Jhin",
@@ -2316,7 +2316,7 @@
           }
         },
         "Jinx": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Jinx",
           "key": "222",
           "name": "Jinx",
@@ -2365,7 +2365,7 @@
           }
         },
         "Kalista": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Kalista",
           "key": "429",
           "name": "Kalista",
@@ -2414,7 +2414,7 @@
           }
         },
         "Karma": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Karma",
           "key": "43",
           "name": "Karma",
@@ -2464,7 +2464,7 @@
           }
         },
         "Karthus": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Karthus",
           "key": "30",
           "name": "Karthus",
@@ -2513,7 +2513,7 @@
           }
         },
         "Kassadin": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Kassadin",
           "key": "38",
           "name": "Kassadin",
@@ -2563,7 +2563,7 @@
           }
         },
         "Katarina": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Katarina",
           "key": "55",
           "name": "Katarina",
@@ -2590,18 +2590,18 @@
           ],
           "partype": "None",
           "stats": {
-            "hp": 510,
-            "hpperlevel": 83,
+            "hp": 590,
+            "hpperlevel": 82,
             "mp": 0,
             "mpperlevel": 0,
-            "movespeed": 345,
-            "armor": 26.88,
+            "movespeed": 340,
+            "armor": 27.88,
             "armorperlevel": 3.5,
-            "spellblock": 32.1,
+            "spellblock": 34.1,
             "spellblockperlevel": 1.25,
             "attackrange": 125,
-            "hpregen": 4.5,
-            "hpregenperlevel": 0.55,
+            "hpregen": 7.5,
+            "hpregenperlevel": 0.7,
             "mpregen": 0,
             "mpregenperlevel": 0,
             "crit": 0,
@@ -2613,7 +2613,7 @@
           }
         },
         "Kayle": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Kayle",
           "key": "10",
           "name": "Kayle",
@@ -2663,7 +2663,7 @@
           }
         },
         "Kennen": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Kennen",
           "key": "85",
           "name": "Kennen",
@@ -2713,7 +2713,7 @@
           }
         },
         "Khazix": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Khazix",
           "key": "121",
           "name": "Kha'Zix",
@@ -2756,14 +2756,14 @@
             "mpregenperlevel": 0.5,
             "crit": 0,
             "critperlevel": 0,
-            "attackdamage": 55.208,
+            "attackdamage": 55.21,
             "attackdamageperlevel": 3.1,
             "attackspeedoffset": -0.065,
             "attackspeedperlevel": 2.7
           }
         },
         "Kindred": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Kindred",
           "key": "203",
           "name": "Kindred",
@@ -2812,7 +2812,7 @@
           }
         },
         "Kled": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Kled",
           "key": "240",
           "name": "Kled",
@@ -2862,7 +2862,7 @@
           }
         },
         "KogMaw": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "KogMaw",
           "key": "96",
           "name": "Kog'Maw",
@@ -2912,7 +2912,7 @@
           }
         },
         "Leblanc": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Leblanc",
           "key": "7",
           "name": "LeBlanc",
@@ -2940,17 +2940,17 @@
           "partype": "MP",
           "stats": {
             "hp": 516,
-            "hpperlevel": 75,
+            "hpperlevel": 80,
             "mp": 334,
             "mpperlevel": 50,
-            "movespeed": 335,
+            "movespeed": 340,
             "armor": 21.88,
             "armorperlevel": 3.5,
             "spellblock": 30,
             "spellblockperlevel": 0,
             "attackrange": 525,
-            "hpregen": 7.42,
-            "hpregenperlevel": 0.55,
+            "hpregen": 8.5,
+            "hpregenperlevel": 0.8,
             "mpregen": 6,
             "mpregenperlevel": 0.8,
             "crit": 0,
@@ -2962,7 +2962,7 @@
           }
         },
         "LeeSin": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "LeeSin",
           "key": "64",
           "name": "Lee Sin",
@@ -3012,7 +3012,7 @@
           }
         },
         "Leona": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Leona",
           "key": "89",
           "name": "Leona",
@@ -3062,7 +3062,7 @@
           }
         },
         "Lissandra": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Lissandra",
           "key": "127",
           "name": "Lissandra",
@@ -3111,7 +3111,7 @@
           }
         },
         "Lucian": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Lucian",
           "key": "236",
           "name": "Lucian",
@@ -3160,7 +3160,7 @@
           }
         },
         "Lulu": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Lulu",
           "key": "117",
           "name": "Lulu",
@@ -3210,7 +3210,7 @@
           }
         },
         "Lux": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Lux",
           "key": "99",
           "name": "Lux",
@@ -3260,7 +3260,7 @@
           }
         },
         "Malphite": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Malphite",
           "key": "54",
           "name": "Malphite",
@@ -3310,7 +3310,7 @@
           }
         },
         "Malzahar": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Malzahar",
           "key": "90",
           "name": "Malzahar",
@@ -3360,7 +3360,7 @@
           }
         },
         "Maokai": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Maokai",
           "key": "57",
           "name": "Maokai",
@@ -3410,7 +3410,7 @@
           }
         },
         "MasterYi": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "MasterYi",
           "key": "11",
           "name": "Master Yi",
@@ -3460,7 +3460,7 @@
           }
         },
         "MissFortune": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "MissFortune",
           "key": "21",
           "name": "Miss Fortune",
@@ -3509,7 +3509,7 @@
           }
         },
         "MonkeyKing": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "MonkeyKing",
           "key": "62",
           "name": "Wukong",
@@ -3559,7 +3559,7 @@
           }
         },
         "Mordekaiser": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Mordekaiser",
           "key": "82",
           "name": "Mordekaiser",
@@ -3608,7 +3608,7 @@
           }
         },
         "Morgana": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Morgana",
           "key": "25",
           "name": "Morgana",
@@ -3658,7 +3658,7 @@
           }
         },
         "Nami": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Nami",
           "key": "267",
           "name": "Nami",
@@ -3708,7 +3708,7 @@
           }
         },
         "Nasus": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Nasus",
           "key": "75",
           "name": "Nasus",
@@ -3758,7 +3758,7 @@
           }
         },
         "Nautilus": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Nautilus",
           "key": "111",
           "name": "Nautilus",
@@ -3808,7 +3808,7 @@
           }
         },
         "Nidalee": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Nidalee",
           "key": "76",
           "name": "Nidalee",
@@ -3858,7 +3858,7 @@
           }
         },
         "Nocturne": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Nocturne",
           "key": "56",
           "name": "Nocturne",
@@ -3908,7 +3908,7 @@
           }
         },
         "Nunu": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Nunu",
           "key": "20",
           "name": "Nunu",
@@ -3958,7 +3958,7 @@
           }
         },
         "Olaf": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Olaf",
           "key": "2",
           "name": "Olaf",
@@ -4008,7 +4008,7 @@
           }
         },
         "Orianna": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Orianna",
           "key": "61",
           "name": "Orianna",
@@ -4058,7 +4058,7 @@
           }
         },
         "Pantheon": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Pantheon",
           "key": "80",
           "name": "Pantheon",
@@ -4108,7 +4108,7 @@
           }
         },
         "Poppy": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Poppy",
           "key": "78",
           "name": "Poppy",
@@ -4158,7 +4158,7 @@
           }
         },
         "Quinn": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Quinn",
           "key": "133",
           "name": "Quinn",
@@ -4208,7 +4208,7 @@
           }
         },
         "Rammus": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Rammus",
           "key": "33",
           "name": "Rammus",
@@ -4258,7 +4258,7 @@
           }
         },
         "RekSai": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "RekSai",
           "key": "421",
           "name": "Rek'Sai",
@@ -4307,7 +4307,7 @@
           }
         },
         "Renekton": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Renekton",
           "key": "58",
           "name": "Renekton",
@@ -4357,7 +4357,7 @@
           }
         },
         "Rengar": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Rengar",
           "key": "107",
           "name": "Rengar",
@@ -4386,28 +4386,28 @@
           "stats": {
             "hp": 586.2,
             "hpperlevel": 90,
-            "mp": 5,
+            "mp": 4,
             "mpperlevel": 0,
             "movespeed": 345,
             "armor": 25.88,
-            "armorperlevel": 3.5,
+            "armorperlevel": 3,
             "spellblock": 32.1,
             "spellblockperlevel": 1.25,
             "attackrange": 125,
-            "hpregen": 4.27,
-            "hpregenperlevel": 0.4,
+            "hpregen": 7,
+            "hpregenperlevel": 0.5,
             "mpregen": 0,
             "mpregenperlevel": 0,
             "crit": 0,
             "critperlevel": 0,
-            "attackdamage": 60.04,
-            "attackdamageperlevel": 3,
-            "attackspeedoffset": -0.08,
-            "attackspeedperlevel": 2.85
+            "attackdamage": 60,
+            "attackdamageperlevel": 1,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 3.5
           }
         },
         "Riven": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Riven",
           "key": "92",
           "name": "Riven",
@@ -4457,7 +4457,7 @@
           }
         },
         "Rumble": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Rumble",
           "key": "68",
           "name": "Rumble",
@@ -4507,7 +4507,7 @@
           }
         },
         "Ryze": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Ryze",
           "key": "13",
           "name": "Ryze",
@@ -4557,7 +4557,7 @@
           }
         },
         "Sejuani": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Sejuani",
           "key": "113",
           "name": "Sejuani",
@@ -4607,7 +4607,7 @@
           }
         },
         "Shaco": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Shaco",
           "key": "35",
           "name": "Shaco",
@@ -4656,7 +4656,7 @@
           }
         },
         "Shen": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Shen",
           "key": "98",
           "name": "Shen",
@@ -4706,7 +4706,7 @@
           }
         },
         "Shyvana": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Shyvana",
           "key": "102",
           "name": "Shyvana",
@@ -4756,7 +4756,7 @@
           }
         },
         "Singed": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Singed",
           "key": "27",
           "name": "Singed",
@@ -4806,7 +4806,7 @@
           }
         },
         "Sion": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Sion",
           "key": "14",
           "name": "Sion",
@@ -4856,7 +4856,7 @@
           }
         },
         "Sivir": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Sivir",
           "key": "15",
           "name": "Sivir",
@@ -4905,7 +4905,7 @@
           }
         },
         "Skarner": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Skarner",
           "key": "72",
           "name": "Skarner",
@@ -4955,7 +4955,7 @@
           }
         },
         "Sona": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Sona",
           "key": "37",
           "name": "Sona",
@@ -5005,7 +5005,7 @@
           }
         },
         "Soraka": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Soraka",
           "key": "16",
           "name": "Soraka",
@@ -5055,7 +5055,7 @@
           }
         },
         "Swain": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Swain",
           "key": "50",
           "name": "Swain",
@@ -5105,7 +5105,7 @@
           }
         },
         "Syndra": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Syndra",
           "key": "134",
           "name": "Syndra",
@@ -5155,7 +5155,7 @@
           }
         },
         "TahmKench": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "TahmKench",
           "key": "223",
           "name": "Tahm Kench",
@@ -5205,7 +5205,7 @@
           }
         },
         "Taliyah": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Taliyah",
           "key": "163",
           "name": "Taliyah",
@@ -5255,7 +5255,7 @@
           }
         },
         "Talon": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Talon",
           "key": "91",
           "name": "Talon",
@@ -5282,11 +5282,11 @@
           ],
           "partype": "MP",
           "stats": {
-            "hp": 582.8,
-            "hpperlevel": 85,
+            "hp": 583,
+            "hpperlevel": 90,
             "mp": 377.2,
             "mpperlevel": 37,
-            "movespeed": 350,
+            "movespeed": 335,
             "armor": 26.88,
             "armorperlevel": 3.5,
             "spellblock": 32.1,
@@ -5298,14 +5298,14 @@
             "mpregenperlevel": 0.5,
             "crit": 0,
             "critperlevel": 0,
-            "attackdamage": 55.208,
+            "attackdamage": 60,
             "attackdamageperlevel": 3.1,
-            "attackspeedoffset": -0.065,
-            "attackspeedperlevel": 2.7
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 2.9
           }
         },
         "Taric": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Taric",
           "key": "44",
           "name": "Taric",
@@ -5355,7 +5355,7 @@
           }
         },
         "Teemo": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Teemo",
           "key": "17",
           "name": "Teemo",
@@ -5405,7 +5405,7 @@
           }
         },
         "Thresh": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Thresh",
           "key": "412",
           "name": "Thresh",
@@ -5455,7 +5455,7 @@
           }
         },
         "Tristana": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Tristana",
           "key": "18",
           "name": "Tristana",
@@ -5505,7 +5505,7 @@
           }
         },
         "Trundle": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Trundle",
           "key": "48",
           "name": "Trundle",
@@ -5555,7 +5555,7 @@
           }
         },
         "Tryndamere": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Tryndamere",
           "key": "23",
           "name": "Tryndamere",
@@ -5605,7 +5605,7 @@
           }
         },
         "TwistedFate": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "TwistedFate",
           "key": "4",
           "name": "Twisted Fate",
@@ -5654,7 +5654,7 @@
           }
         },
         "Twitch": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Twitch",
           "key": "29",
           "name": "Twitch",
@@ -5704,7 +5704,7 @@
           }
         },
         "Udyr": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Udyr",
           "key": "77",
           "name": "Udyr",
@@ -5754,7 +5754,7 @@
           }
         },
         "Urgot": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Urgot",
           "key": "6",
           "name": "Urgot",
@@ -5804,7 +5804,7 @@
           }
         },
         "Varus": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Varus",
           "key": "110",
           "name": "Varus",
@@ -5854,7 +5854,7 @@
           }
         },
         "Vayne": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Vayne",
           "key": "67",
           "name": "Vayne",
@@ -5904,7 +5904,7 @@
           }
         },
         "Veigar": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Veigar",
           "key": "45",
           "name": "Veigar",
@@ -5953,7 +5953,7 @@
           }
         },
         "Velkoz": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Velkoz",
           "key": "161",
           "name": "Vel'Koz",
@@ -6002,7 +6002,7 @@
           }
         },
         "Vi": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Vi",
           "key": "254",
           "name": "Vi",
@@ -6052,7 +6052,7 @@
           }
         },
         "Viktor": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Viktor",
           "key": "112",
           "name": "Viktor",
@@ -6101,7 +6101,7 @@
           }
         },
         "Vladimir": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Vladimir",
           "key": "8",
           "name": "Vladimir",
@@ -6151,7 +6151,7 @@
           }
         },
         "Volibear": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Volibear",
           "key": "106",
           "name": "Volibear",
@@ -6201,7 +6201,7 @@
           }
         },
         "Warwick": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Warwick",
           "key": "19",
           "name": "Warwick",
@@ -6251,7 +6251,7 @@
           }
         },
         "Xerath": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Xerath",
           "key": "101",
           "name": "Xerath",
@@ -6301,7 +6301,7 @@
           }
         },
         "XinZhao": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "XinZhao",
           "key": "5",
           "name": "Xin Zhao",
@@ -6351,7 +6351,7 @@
           }
         },
         "Yasuo": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Yasuo",
           "key": "157",
           "name": "Yasuo",
@@ -6401,7 +6401,7 @@
           }
         },
         "Yorick": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Yorick",
           "key": "83",
           "name": "Yorick",
@@ -6451,7 +6451,7 @@
           }
         },
         "Zac": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Zac",
           "key": "154",
           "name": "Zac",
@@ -6501,7 +6501,7 @@
           }
         },
         "Zed": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Zed",
           "key": "238",
           "name": "Zed",
@@ -6551,7 +6551,7 @@
           }
         },
         "Ziggs": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Ziggs",
           "key": "115",
           "name": "Ziggs",
@@ -6600,7 +6600,7 @@
           }
         },
         "Zilean": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Zilean",
           "key": "26",
           "name": "Zilean",
@@ -6650,7 +6650,7 @@
           }
         },
         "Zyra": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Zyra",
           "key": "143",
           "name": "Zyra",
@@ -6703,32 +6703,32 @@
     },
     "headers": {
       "content-type": "application/json",
-      "content-length": "126739",
+      "content-length": "126725",
       "connection": "close",
       "accept-ranges": "bytes",
       "access-control-allow-origin": "*",
       "cache-control": "max-age=315360000, public",
-      "date": "Tue, 18 Oct 2016 03:00:05 GMT",
-      "etag": "\"289f4f-1ef13-53f07234b1f40\"",
+      "date": "Fri, 04 Nov 2016 03:00:06 GMT",
+      "etag": "\"30bf3d-1ef05-5406e22348200\"",
       "expires": "Thu, 31 Dec 2099 00:00:00 GMT",
-      "last-modified": "Mon, 17 Oct 2016 03:26:13 GMT",
+      "last-modified": "Thu, 03 Nov 2016 23:44:08 GMT",
       "server": "Apache/2.2.29 (Amazon)",
-      "via": "1.1 varnish, 1.1 5a823cd7a77f31b6fc2df20714f357d8.cloudfront.net (CloudFront)",
-      "x-varnish": "2092555336",
-      "age": "1178209",
+      "via": "1.1 varnish, 1.1 901427b25164532ae97382d031da28b7.cloudfront.net (CloudFront)",
+      "x-varnish": "2423686877",
+      "age": "819937",
       "x-cache": "Hit from cloudfront",
-      "x-amz-cf-id": "GZMeJPXlAQzq89mavI8yzEM5DBJDB6vpk35q9qaILm1WRM0BA42cqg=="
+      "x-amz-cf-id": "6TMy-4RBYApcofmXg6uijlYbQCkxYJN2VL5ZWhu-ZT4Zrlfge5aN_Q=="
     }
   },
   {
     "scope": "https://ddragon.leagueoflegends.com:443",
     "method": "GET",
-    "path": "/cdn/6.21.1/data/en_US/item.json",
+    "path": "/cdn/6.22.1/data/en_US/item.json",
     "body": "",
     "status": 200,
     "response": {
       "type": "item",
-      "version": "6.21.1",
+      "version": "6.22.1",
       "basic": {
         "name": "",
         "rune": {
@@ -6834,7 +6834,6 @@
       "data": {
         "1001": {
           "name": "Boots of Speed",
-          "group": "BootsNormal",
           "description": "<groupLimit>Limited to 1.</groupLimit><br><br><unique>UNIQUE Passive - Enhanced Movement:</unique> +25 Movement Speed",
           "colloq": ";",
           "plaintext": "Slightly increases Movement Speed",
@@ -7145,8 +7144,8 @@
             "3052",
             "3044",
             "3067",
-            "3801",
             "3211",
+            "3801",
             "3136",
             "3748"
           ],
@@ -7192,7 +7191,9 @@
             "3024",
             "3082",
             "3075",
-            "2053"
+            "2053",
+            "3105",
+            "3109"
           ],
           "image": {
             "full": "1029.png",
@@ -7282,7 +7283,9 @@
             "3028",
             "3140",
             "3155",
-            "3105"
+            "3105",
+            "3190",
+            "3814"
           ],
           "image": {
             "full": "1033.png",
@@ -7332,7 +7335,8 @@
             "3122",
             "3134",
             "3144",
-            "3155"
+            "3155",
+            "3252"
           ],
           "image": {
             "full": "1036.png",
@@ -7379,7 +7383,8 @@
             "3124",
             "3139",
             "3181",
-            "3812"
+            "3812",
+            "3814"
           ],
           "image": {
             "full": "1037.png",
@@ -7504,7 +7509,7 @@
         },
         "1041": {
           "name": "Hunter's Machete",
-          "description": "<stats>+8% Life Steal vs. Monsters</stats><br><br><unique>UNIQUE Passive - Nail:</unique> Basic attacks deal 20 bonus damage on hit vs. Monsters. Killing monsters grants <font color='#99BBBB'><a href='SpecialJungleExperience'>special bonus experience</a></font>.",
+          "description": "<stats>+10% Life Steal vs. Monsters</stats><br><br><unique>UNIQUE Passive - Nail:</unique> Basic attacks deal 25 bonus damage on hit vs. Monsters. Killing monsters grants <font color='#99BBBB'><a href='SpecialJungleExperience'>special bonus experience</a></font>.",
           "colloq": ";jungle;Jungle",
           "plaintext": "Provides damage and life steal versus Monsters",
           "into": [
@@ -7543,8 +7548,8 @@
           "stats": {},
           "effect": {
             "Effect1Amount": "12",
-            "Effect2Amount": "20",
-            "Effect3Amount": "0.08",
+            "Effect2Amount": "25",
+            "Effect3Amount": "0.1",
             "Effect4Amount": "2",
             "Effect5Amount": "0",
             "Effect6Amount": "0.1",
@@ -7795,7 +7800,6 @@
         },
         "1054": {
           "name": "Doran's Shield",
-          "group": "DoransItems",
           "description": "<stats>+80 Health</stats><br><br><passive>Passive: </passive>Restores 6 Health every 5 seconds.<br><unique>UNIQUE Passive:</unique> Blocks 8 damage from single target attacks and spells from champions.",
           "colloq": ";dshield",
           "plaintext": "Good defensive starting item",
@@ -7825,7 +7829,7 @@
             "8": true,
             "10": true,
             "11": true,
-            "12": false,
+            "12": true,
             "14": false
           },
           "stats": {
@@ -7838,7 +7842,6 @@
         },
         "1055": {
           "name": "Doran's Blade",
-          "group": "DoransItems",
           "description": "<stats>+8 Attack Damage<br>+80 Health<br>+3% Life Steal</stats>",
           "colloq": ";dblade",
           "plaintext": "Good starting item for attackers",
@@ -7869,7 +7872,7 @@
             "8": true,
             "10": true,
             "11": true,
-            "12": false,
+            "12": true,
             "14": false
           },
           "stats": {
@@ -7883,7 +7886,6 @@
         },
         "1056": {
           "name": "Doran's Ring",
-          "group": "DoransItems",
           "description": "<stats>+60 Health<br>+15 Ability Power<br><mana>+50% Base Mana Regen </mana></stats><br><br><mana><passive>Passive:</passive> Restores 4 Mana upon killing a unit.</mana>",
           "colloq": ";dring",
           "plaintext": "Good starting item for casters",
@@ -7914,7 +7916,7 @@
             "8": true,
             "10": true,
             "11": true,
-            "12": false,
+            "12": true,
             "14": false
           },
           "stats": {
@@ -8111,7 +8113,6 @@
         },
         "1400": {
           "name": "Enchantment: Warrior",
-          "group": "JungleItems",
           "description": "<stats>+60 Attack Damage<br>+10% Cooldown Reduction</stats>",
           "colloq": ";",
           "plaintext": "Grants Attack Damage and Cooldown Reduction",
@@ -8150,7 +8151,7 @@
           },
           "effect": {
             "Effect1Amount": "30",
-            "Effect2Amount": "20",
+            "Effect2Amount": "25",
             "Effect3Amount": "1.8",
             "Effect4Amount": "5",
             "Effect5Amount": "30",
@@ -8162,7 +8163,6 @@
         },
         "1401": {
           "name": "Enchantment: Cinderhulk",
-          "group": "JungleItems",
           "description": "<stats>+400 Health<br>+15% Bonus Health</stats><br><br><unique>UNIQUE Passive - Immolate:</unique> Deals 7 (+2 per champion level) magic damage a second to nearby enemies while in combat. Deals 100% bonus damage to monsters. ",
           "colloq": ";",
           "plaintext": "Grants Health and Immolate Aura",
@@ -8201,7 +8201,7 @@
           },
           "effect": {
             "Effect1Amount": "30",
-            "Effect2Amount": "20",
+            "Effect2Amount": "25",
             "Effect3Amount": "1.8",
             "Effect4Amount": "5",
             "Effect5Amount": "30",
@@ -8213,7 +8213,6 @@
         },
         "1402": {
           "name": "Enchantment: Runic Echoes",
-          "group": "JungleItems",
           "description": "<stats>+60 Ability Power<br>+7% Movement Speed</stats><br><br><unique>UNIQUE Passive - Echo:</unique> Gain charges upon moving or casting. At 100 charges, the next damaging spell hit expends all charges to deal 60 (+10% of Ability Power) bonus magic damage to up to 4 targets on hit.<br><br>This effect deals 250% damage to Large Monsters. Hitting a Large Monster with this effect will restore 18% of your missing Mana.",
           "colloq": ";",
           "plaintext": "Grants Ability Power and periodically empowers your Spells",
@@ -8254,7 +8253,7 @@
           },
           "effect": {
             "Effect1Amount": "30",
-            "Effect2Amount": "20",
+            "Effect2Amount": "25",
             "Effect3Amount": "1.8",
             "Effect4Amount": "5",
             "Effect5Amount": "30",
@@ -8266,7 +8265,6 @@
         },
         "1408": {
           "name": "Enchantment: Warrior",
-          "group": "JungleItems",
           "description": "<stats>+60 Attack Damage<br>+10% Cooldown Reduction</stats>",
           "colloq": ";",
           "plaintext": "Grants Attack Damage and Cooldown Reduction",
@@ -8305,7 +8303,7 @@
           },
           "effect": {
             "Effect1Amount": "30",
-            "Effect2Amount": "20",
+            "Effect2Amount": "25",
             "Effect3Amount": "1.8",
             "Effect4Amount": "5",
             "Effect5Amount": "30",
@@ -8317,7 +8315,6 @@
         },
         "1409": {
           "name": "Enchantment: Cinderhulk",
-          "group": "JungleItems",
           "description": "<stats>+400 Health<br>+15% Bonus Health</stats><br><br><unique>UNIQUE Passive - Immolate:</unique> Deals 7 (+2 per champion level) magic damage a second to nearby enemies while in combat. Deals 100% bonus damage to monsters. ",
           "colloq": ";",
           "plaintext": "Grants Health and Immolate Aura",
@@ -8356,7 +8353,7 @@
           },
           "effect": {
             "Effect1Amount": "30",
-            "Effect2Amount": "20",
+            "Effect2Amount": "25",
             "Effect3Amount": "1.8",
             "Effect4Amount": "5",
             "Effect5Amount": "30",
@@ -8368,7 +8365,6 @@
         },
         "1410": {
           "name": "Enchantment: Runic Echoes",
-          "group": "JungleItems",
           "description": "<stats>+60 Ability Power<br>+7% Movement Speed</stats><br><br><unique>UNIQUE Passive - Echo:</unique> Gain charges upon moving or casting. At 100 charges, the next damaging spell hit expends all charges to deal 60 (+10% of Ability Power) bonus magic damage to up to 4 targets on hit.<br><br>This effect deals 250% damage to Large Monsters. Hitting a Large Monster with this effect will restore 18% of your missing Mana.",
           "colloq": ";",
           "plaintext": "Grants Ability Power and periodically empowers your Spells",
@@ -8409,7 +8405,7 @@
           },
           "effect": {
             "Effect1Amount": "30",
-            "Effect2Amount": "20",
+            "Effect2Amount": "25",
             "Effect3Amount": "1.8",
             "Effect4Amount": "5",
             "Effect5Amount": "30",
@@ -8421,7 +8417,6 @@
         },
         "1412": {
           "name": "Enchantment: Warrior",
-          "group": "JungleItems",
           "description": "<stats>+60 Attack Damage<br>+10% Cooldown Reduction</stats>",
           "colloq": ";",
           "plaintext": "Grants Attack Damage and Cooldown Reduction",
@@ -8460,7 +8455,7 @@
           },
           "effect": {
             "Effect1Amount": "30",
-            "Effect2Amount": "20",
+            "Effect2Amount": "25",
             "Effect3Amount": "1.8",
             "Effect4Amount": "5",
             "Effect5Amount": "30",
@@ -8472,7 +8467,6 @@
         },
         "1413": {
           "name": "Enchantment: Cinderhulk",
-          "group": "JungleItems",
           "description": "<stats>+400 Health<br>+15% Bonus Health</stats><br><br><unique>UNIQUE Passive - Immolate:</unique> Deals 7 (+2 per champion level) magic damage a second to nearby enemies while in combat. Deals 100% bonus damage to monsters. ",
           "colloq": ";",
           "plaintext": "Grants Health and Immolate Aura",
@@ -8511,7 +8505,7 @@
           },
           "effect": {
             "Effect1Amount": "30",
-            "Effect2Amount": "20",
+            "Effect2Amount": "25",
             "Effect3Amount": "1.8",
             "Effect4Amount": "5",
             "Effect5Amount": "30",
@@ -8523,7 +8517,6 @@
         },
         "1414": {
           "name": "Enchantment: Runic Echoes",
-          "group": "JungleItems",
           "description": "<stats>+60 Ability Power<br>+7% Movement Speed</stats><br><br><unique>UNIQUE Passive - Echo:</unique> Gain charges upon moving or casting. At 100 charges, the next damaging spell hit expends all charges to deal 60 (+10% of Ability Power) bonus magic damage to up to 4 targets on hit.<br><br>This effect deals 250% damage to Large Monsters. Hitting a Large Monster with this effect will restore 18% of your missing Mana.",
           "colloq": ";",
           "plaintext": "Grants Ability Power and periodically empowers your Spells",
@@ -8564,7 +8557,7 @@
           },
           "effect": {
             "Effect1Amount": "30",
-            "Effect2Amount": "20",
+            "Effect2Amount": "25",
             "Effect3Amount": "1.8",
             "Effect4Amount": "5",
             "Effect5Amount": "30",
@@ -8576,7 +8569,6 @@
         },
         "1416": {
           "name": "Enchantment: Bloodrazor",
-          "group": "JungleItems",
           "description": "<stats>+50% Attack Speed</stats><br><br><unique>UNIQUE Passive:</unique> Basic attacks deal 4% of the target's maximum Health in bonus physical damage (max 75 vs. monsters and minions) on hit.",
           "colloq": ";",
           "plaintext": "Increases Attack Speed and deals damage based on the target's Health",
@@ -8615,7 +8607,7 @@
           },
           "effect": {
             "Effect1Amount": "30",
-            "Effect2Amount": "20",
+            "Effect2Amount": "25",
             "Effect3Amount": "1.8",
             "Effect4Amount": "5",
             "Effect5Amount": "30",
@@ -8627,7 +8619,6 @@
         },
         "1418": {
           "name": "Enchantment: Bloodrazor",
-          "group": "JungleItems",
           "description": "<stats>+50% Attack Speed</stats><br><br><unique>UNIQUE Passive:</unique> Basic attacks deal 4% of the target's maximum Health in bonus physical damage (max 75 vs. monsters and minions) on hit.",
           "colloq": ";",
           "plaintext": "Increases Attack Speed and deals damage based on the target's Health",
@@ -8666,7 +8657,7 @@
           },
           "effect": {
             "Effect1Amount": "30",
-            "Effect2Amount": "20",
+            "Effect2Amount": "25",
             "Effect3Amount": "1.8",
             "Effect4Amount": "5",
             "Effect5Amount": "30",
@@ -8678,7 +8669,6 @@
         },
         "1419": {
           "name": "Enchantment: Bloodrazor",
-          "group": "JungleItems",
           "description": "<stats>+50% Attack Speed</stats><br><br><unique>UNIQUE Passive:</unique> Basic attacks deal 4% of the target's maximum Health in bonus physical damage (max 75 vs. monsters and minions) on hit.",
           "colloq": ";",
           "plaintext": "Increases Attack Speed and deals damage based on the target's Health",
@@ -8717,7 +8707,7 @@
           },
           "effect": {
             "Effect1Amount": "30",
-            "Effect2Amount": "20",
+            "Effect2Amount": "25",
             "Effect3Amount": "1.8",
             "Effect4Amount": "5",
             "Effect5Amount": "30",
@@ -8729,7 +8719,6 @@
         },
         "2003": {
           "name": "Health Potion",
-          "group": "HealthPotion",
           "description": "<groupLimit>Limited to 5 at one time. Limited to 1 type of Healing Potion.</groupLimit><br><br><consumable>Click to Consume:</consumable> Restores 150 Health over 15 seconds.",
           "colloq": ";",
           "plaintext": "Consume to restore Health over time",
@@ -8806,7 +8795,6 @@
         },
         "2010": {
           "name": "Total Biscuit of Rejuvenation",
-          "group": "HealthPotion",
           "description": "<consumable>Click to Consume:</consumable> Restores 15 Health and 15 Mana immediately and then 150 Health over 15 seconds.",
           "colloq": ";",
           "plaintext": "",
@@ -8895,7 +8883,6 @@
         },
         "2031": {
           "name": "Refillable Potion",
-          "group": "FlaskGroup",
           "description": "<groupLimit>Limited to 1 type of Healing Potion.</groupLimit><br><br><active>UNIQUE Active:</active> Consumes a charge to restore 125 Health over 12 seconds. Holds up to 2 charges and refills upon visiting the shop.",
           "colloq": ";",
           "plaintext": "Restores Health over time. Refills at shop.",
@@ -8943,7 +8930,6 @@
         },
         "2032": {
           "name": "Hunter's Potion",
-          "group": "FlaskGroup",
           "description": "<groupLimit>Limited to 1 type of Healing Potion.</groupLimit><br><br><active>UNIQUE Active:</active> Consumes a charge to restore 60 Health and 35 Mana over 8 seconds. Holds up to 5 charges and refills upon visiting the shop.<br><br>Killing a Large Monster grants 1 charge.<br><br><rules>(Killing a Large Monster at full charges will automatically consume the newest charge.)</rules>",
           "colloq": ";",
           "plaintext": "Restores Health and Mana over time - Refills at shop and has increased capacity",
@@ -8992,7 +8978,6 @@
         },
         "2033": {
           "name": "Corrupting Potion",
-          "group": "FlaskGroup",
           "description": "<groupLimit>Limited to 1 type of Healing Potion.</groupLimit><br><br><active>UNIQUE Active:</active> Consumes a charge to restore 125 Health and 75 Mana over 12 seconds and grants <font color='#FF8811'><u>Touch of Corruption</u></font> during that time. Holds up to 3 charges that refills upon visiting the shop.<br><br><font color='#FF8811'><u>Touch of Corruption:</u></font> Damaging spells and attacks burn enemy champions for <levelScale>15 - 30</levelScale> magic damage over 3 seconds. (Half Damage for Area of Effect or Damage over Time spells. Damage increases with champion level.)<br><br><rules>(Corrupting Potion can be used even at full Health and Mana.)</rules>",
           "colloq": ";",
           "plaintext": "Restores Health and Mana over time and boosts combat power - Refills at Shop",
@@ -9042,50 +9027,6 @@
             "Effect8Amount": "3"
           },
           "depth": 2
-        },
-        "2043": {
-          "name": "Vision Ward",
-          "group": "PinkWards",
-          "description": "<groupLimit>Can only carry 2 Vision Wards in inventory.</groupLimit><br><br><consumable>Click to Consume:</consumable> Places a visible ward that reveals the surrounding area and invisible units in the area until killed. Limit 1 <font color='#BBFFFF'>Vision Ward</font> on the map per player.<br><br><rules>(Revealing a ward in this manner grants a portion of the gold reward when that unit is killed.)</rules>",
-          "colloq": "pink;",
-          "plaintext": "Use to provide vision and stealth detection in an area until destroyed",
-          "consumed": true,
-          "stacks": 2,
-          "into": [],
-          "image": {
-            "full": "2043.png",
-            "sprite": "item0.png",
-            "group": "item",
-            "x": 48,
-            "y": 240,
-            "w": 48,
-            "h": 48
-          },
-          "gold": {
-            "base": 75,
-            "purchasable": true,
-            "total": 75,
-            "sell": 30
-          },
-          "tags": [
-            "Consumable",
-            "Lane",
-            "Stealth",
-            "Vision"
-          ],
-          "maps": {
-            "1": false,
-            "8": false,
-            "10": false,
-            "11": true,
-            "12": false,
-            "14": false
-          },
-          "stats": {},
-          "effect": {
-            "Effect1Amount": "1",
-            "Effect2Amount": "2"
-          }
         },
         "2045": {
           "name": "Ruby Sightstone",
@@ -9261,7 +9202,6 @@
         },
         "2051": {
           "name": "Guardian's Horn",
-          "group": "GuardianItems",
           "description": "<stats>+150 Health</stats><br><br><passive>Passive: </passive>Restores 20 Health every 5 seconds.<br><unique>UNIQUE Passive:</unique> Blocks 12 damage from attacks and spells from champions (25% effectiveness vs. damage over time abilities).<br><br><groupLimit>Limited to 1 Guardian's Item.</groupLimit>",
           "colloq": "Golden Arm of Kobe;Golden Bicep of Kobe;Horn; Horn of the ManWolf; ManWolf",
           "plaintext": "Good starting item for tanks",
@@ -9305,7 +9245,6 @@
         },
         "2052": {
           "name": "Poro-Snax",
-          "group": "PoroSnax",
           "description": "This savory blend of free-range, grass-fed Avarosan game hens and organic, non-ZMO Freljordian herbs contains the essential nutrients necessary to keep your Poro purring with pleasure.<br><br><i>All proceeds will be donated towards fighting Noxian animal cruelty.</i>",
           "colloq": ";",
           "plaintext": "",
@@ -9392,7 +9331,6 @@
         },
         "2054": {
           "name": "Diet Poro-Snax",
-          "group": "RelicBase",
           "description": "All the flavor of regular Poro-Snax, without the calories! Keeps your Poro happy AND healthy.<br><br><consumable>Click to Consume:</consumable> Gives your Poros a delicious healthy treat.",
           "colloq": ";",
           "plaintext": "",
@@ -9425,9 +9363,51 @@
           },
           "stats": {}
         },
+        "2055": {
+          "name": "Control Ward",
+          "description": "<groupLimit>Can only carry 3 Control Wards in inventory.</groupLimit><br><br><consumable>Click to Consume:</consumable> Places a ward that reveals the surrounding area. This device will disable and reveal nearby <a hred='wards'>wards</a> and hidden <a hred='traps'>traps</a>. Control Wards do not disable other Control Wards. Camouflaged units will also be revealed. <br><br>Limit 1 <font color='#BBFFFF'>Control Ward</font> on the map per player.",
+          "colloq": "orange;",
+          "plaintext": "Used to disable wards and invisible traps in an area.",
+          "consumed": true,
+          "stacks": 3,
+          "into": [],
+          "image": {
+            "full": "2055.png",
+            "sprite": "item2.png",
+            "group": "item",
+            "x": 144,
+            "y": 192,
+            "w": 48,
+            "h": 48
+          },
+          "gold": {
+            "base": 75,
+            "purchasable": true,
+            "total": 75,
+            "sell": 30
+          },
+          "tags": [
+            "Consumable",
+            "Lane",
+            "Stealth",
+            "Vision"
+          ],
+          "maps": {
+            "1": false,
+            "8": false,
+            "10": false,
+            "11": true,
+            "12": false,
+            "14": false
+          },
+          "stats": {},
+          "effect": {
+            "Effect1Amount": "1",
+            "Effect2Amount": "3"
+          }
+        },
         "2138": {
           "name": "Elixir of Iron",
-          "group": "Flasks",
           "description": "<stats><levelLimit>Level 9 required to purchase.</levelLimit></stats><br><br><consumable>Click to Consume:</consumable> Grants +300 Health, 25% Tenacity, increased champion size, and <font color='#FF8811'><u>Path of Iron</u></font> for 3 minutes.<br><br><font color='#FF8811'><u>Path of Iron:</u></font> Moving leaves a path behind that boosts allied champion's Movement Speed by 15%.<br><br><rules>(Only one Elixir effect may be active at a time.)</rules>",
           "colloq": ";white",
           "plaintext": "Temporarily increases defenses. Leaves a trail for allies to follow.",
@@ -9477,7 +9457,6 @@
         },
         "2139": {
           "name": "Elixir of Sorcery",
-          "group": "Flasks",
           "description": "<stats><levelLimit>Level 9 required to purchase.</levelLimit></stats><br><br><consumable>Click to Consume:</consumable> Grants +50 Ability Power, 15 bonus Mana Regen per 5 seconds and <font color='#FF8811'><u>Sorcery</u></font> for 3 minutes. <br><br><font color='#FF8811'><u>Sorcery:</u></font> Damaging a champion or turret deals 25 bonus True Damage. This effect has a 5 second cooldown versus champions but no cooldown versus turrets.<br><br><rules>(Only one Elixir effect may be active at a time.)</rules><br>",
           "colloq": ";blue",
           "plaintext": "Temporarily grants Ability Power and Bonus Damage to champions and turrets.",
@@ -9526,7 +9505,6 @@
         },
         "2140": {
           "name": "Elixir of Wrath",
-          "group": "Flasks",
           "description": "<stats><levelLimit>Level 9 required to purchase.</levelLimit></stats><br><br><consumable>Click to Consume:</consumable> Grants +30 Attack Damage and <font color='#FF8811'><u>Bloodlust</u></font> for 3 minutes.<br><br><font color='#FF8811'><u>Bloodlust:</u></font> Dealing physical damage to champions heals for 15% of the damage dealt.<br><br><rules>(Only one Elixir effect may be active at a time.)</rules>",
           "colloq": ";red",
           "plaintext": "Temporarily grants Attack Damage and heals you when dealing physical damage to champions.",
@@ -9576,7 +9554,6 @@
         },
         "2301": {
           "name": "Eye of the Watchers",
-          "group": "GoldBase",
           "description": "<stats>+200 Health<br><mana>+100% Base Mana Regen </mana><br>+25 Ability Power<br>+10% Cooldown Reduction<br>+2 Gold per 10 seconds</stats><br><br><unique>UNIQUE Passive - Tribute:</unique> Spells and basic attacks against champions or buildings deal 15 additional damage and grant 15 Gold. This can occur up to 3 times every 30 seconds.<br><active>UNIQUE Active - Warding:</active> Consumes a charge to place a <font color='#BBFFFF'>Stealth Ward</font> that reveals the surrounding area for 150 seconds. Holds up to 4 charges which refill upon visiting the shop. <br><br><groupLimit>Limited to 1 Gold Income Item.</groupLimit><br><br><rules>(A player may only have 3 <font color='#BBFFFF'>Stealth Wards</font> on the map at one time. Unique Passives with the same name don't stack.)</rules>",
           "colloq": ";",
           "plaintext": "Provides Ability Power and Stealth Wards over time",
@@ -9635,8 +9612,7 @@
         },
         "2302": {
           "name": "Eye of the Oasis",
-          "group": "GoldBase",
-          "description": "<stats>+200 Health<br>+150% Base Health Regen <br><mana>+100% Base Mana Regen </mana><br>+10% Cooldown Reduction</stats><br><br><unique>UNIQUE Passive - Favor:</unique> Being near a minion's death without dealing the killing blow grants 6 Gold and 10 Health.<br><active>UNIQUE Active - Warding:</active> Consumes a charge to place a <font color='#BBFFFF'>Stealth Ward</font> that reveals the surrounding area for 150 seconds. Holds up to 4 charges which refill upon visiting the shop.<br><br><groupLimit>Limited to 1 Gold Income Item.</groupLimit><br><br><rules>(A player may only have 3 <font color='#BBFFFF'>Stealth Wards</font> on the map at one time. Unique Passives with the same name don't stack.)</rules>",
+          "description": "<stats>+200 Health<br>+100% Base Health Regen <br><mana>+100% Base Mana Regen </mana><br>+10% Cooldown Reduction</stats><br><br><unique>UNIQUE Passive - Favor:</unique> Being near a minion's death without dealing the killing blow grants 6 Gold and 10 Health.<br><active>UNIQUE Active - Warding:</active> Consumes a charge to place a <font color='#BBFFFF'>Stealth Ward</font> that reveals the surrounding area for 150 seconds. Holds up to 4 charges which refill upon visiting the shop.<br><br><groupLimit>Limited to 1 Gold Income Item.</groupLimit><br><br><rules>(A player may only have 3 <font color='#BBFFFF'>Stealth Wards</font> on the map at one time. Unique Passives with the same name don't stack.)</rules>",
           "colloq": ";",
           "plaintext": "Provides Regeneration and Stealth Wards over time",
           "from": [
@@ -9654,10 +9630,10 @@
             "h": 48
           },
           "gold": {
-            "base": 550,
+            "base": 250,
             "purchasable": true,
-            "total": 2200,
-            "sell": 880
+            "total": 1900,
+            "sell": 760
           },
           "tags": [
             "Active",
@@ -9692,8 +9668,7 @@
         },
         "2303": {
           "name": "Eye of the Equinox",
-          "group": "GoldBase",
-          "description": "<stats>+500 Health<br>+100% Base Health Regen <br>+2 Gold per 10 seconds</stats><br><br><unique>UNIQUE Passive - Spoils of War:</unique> Melee basic attacks execute minions below 320 (+20 per level) Health. Killing a minion heals the owner and the nearest allied champion for 50 Health and grants them kill Gold. These effects require a nearby ally. Recharges every 30 seconds. Max 4 charges.<br><active>UNIQUE Active - Warding:</active> Consumes a charge to place a <font color='#BBFFFF'>Stealth Ward</font> that reveals the surrounding area for 150 seconds. Holds up to 4 charges which refill upon visiting the shop.<br><br><groupLimit>Limited to 1 Gold Income Item.</groupLimit><br><br><rules>(A player may only have 3 <font color='#BBFFFF'>Stealth Wards</font> on the map at one time. Unique Passives with the same name don't stack.)</rules>",
+          "description": "<stats>+500 Health<br>+200% Base Health Regen <br>+2 Gold per 10 seconds</stats><br><br><unique>UNIQUE Passive - Spoils of War:</unique> Melee basic attacks execute minions below 320 (+20 per level) Health. Killing a minion heals the owner and the nearest allied champion for 50 Health and grants them kill Gold. These effects require a nearby ally. Recharges every 30 seconds. Max 4 charges.<br><active>UNIQUE Active - Warding:</active> Consumes a charge to place a <font color='#BBFFFF'>Stealth Ward</font> that reveals the surrounding area for 150 seconds. Holds up to 4 charges which refill upon visiting the shop.<br><br><groupLimit>Limited to 1 Gold Income Item.</groupLimit><br><br><rules>(A player may only have 3 <font color='#BBFFFF'>Stealth Wards</font> on the map at one time. Unique Passives with the same name don't stack.)</rules>",
           "colloq": ";",
           "plaintext": "Provides Health and Stealth Wards over time",
           "from": [
@@ -9748,9 +9723,9 @@
         },
         "3001": {
           "name": "Abyssal Scepter",
-          "description": "<stats>+60 Ability Power<br>+60 Magic Resist<br>+10% Cooldown Reduction</stats><br><br><aura>UNIQUE Aura:</aura> Reduces the Magic Resist of nearby enemy champions by <levelScale>10 - 25</levelScale>.",
+          "description": "<stats>+60 Ability Power<br>+60 Magic Resist<br>+10% Cooldown Reduction</stats><br><br><aura>UNIQUE Aura:</aura> Nearby enemy champions take 10% more magic damage.",
           "colloq": ";",
-          "plaintext": "Reduces Magic Resist of nearby enemies",
+          "plaintext": "Nearby enemies take more magic damage",
           "from": [
             "3108",
             "1057",
@@ -9793,7 +9768,8 @@
           },
           "effect": {
             "Effect1Amount": "-10",
-            "Effect2Amount": "-25"
+            "Effect2Amount": "-25",
+            "Effect3Amount": "0.1"
           },
           "depth": 3
         },
@@ -9910,7 +9886,6 @@
         },
         "3006": {
           "name": "Berserker's Greaves",
-          "group": "BootsUpgrades",
           "description": "<stats> +35% Attack Speed</stats><br><br><unique>UNIQUE Passive - Enhanced Movement:</unique> +45 Movement Speed",
           "colloq": ";",
           "plaintext": "Enhances Movement Speed and Attack Speed",
@@ -10068,7 +10043,6 @@
         },
         "3009": {
           "name": "Boots of Swiftness",
-          "group": "BootsUpgrades",
           "description": "<unique>UNIQUE Passive - Enhanced Movement:</unique> +55 Movement Speed<br><unique>UNIQUE Passive - Slow Resist:</unique> Movement slowing effects are reduced by 25%.",
           "colloq": ";",
           "plaintext": "Enhances Movement Speed and reduces the effect of slows",
@@ -10173,7 +10147,6 @@
         },
         "3020": {
           "name": "Sorcerer's Shoes",
-          "group": "BootsUpgrades",
           "description": "<stats>+15 <a href='FlatMagicPen'>Magic Penetration</a></stats><br><br><unique>UNIQUE Passive - Enhanced Movement:</unique> +45 Movement Speed",
           "colloq": ";",
           "plaintext": "Enhances Movement Speed and magic damage",
@@ -10282,6 +10255,7 @@
             "3110",
             "3025",
             "3050",
+            "3060",
             "3187"
           ],
           "image": {
@@ -10407,7 +10381,7 @@
             "8": true,
             "10": false,
             "11": true,
-            "12": false,
+            "12": true,
             "14": false
           },
           "stats": {
@@ -10481,7 +10455,7 @@
         },
         "3028": {
           "name": "Chalice of Harmony",
-          "description": "<stats>+25 Magic Resist<br><mana>+50% Base Mana Regen </mana></stats><br><br><unique>UNIQUE Passive:</unique> Increases Base Health Regeneration by 100% if current Health % is lower than current Mana %.  <br><br>Increases Base Mana Regeneration by 100% if current Mana % is lower than current Health %.",
+          "description": "<stats>+25 Magic Resist<br><mana>+50% Base Mana Regen </mana></stats><br><br><unique>UNIQUE Passive:</unique> Grants bonus % Base Health Regen equal to your bonus % Base Mana Regen.</unique>",
           "colloq": ";",
           "plaintext": "Increases Mana and Health Regeneration",
           "from": [
@@ -10503,10 +10477,10 @@
             "h": 48
           },
           "gold": {
-            "base": 200,
+            "base": 100,
             "purchasable": true,
-            "total": 900,
-            "sell": 630
+            "total": 800,
+            "sell": 560
           },
           "tags": [
             "HealthRegen",
@@ -11192,7 +11166,6 @@
         },
         "3047": {
           "name": "Ninja Tabi",
-          "group": "BootsUpgrades",
           "description": "<stats>+30 Armor</stats><br><br><unique>UNIQUE Passive:</unique> Blocks 12% of the damage from basic attacks.<br><unique>UNIQUE Passive - Enhanced Movement:</unique> +45 Movement Speed",
           "colloq": ";",
           "plaintext": "Enhances Movement Speed and reduces incoming basic attack damage",
@@ -11313,10 +11286,10 @@
             "h": 48
           },
           "gold": {
-            "base": 480,
+            "base": 380,
             "purchasable": true,
-            "total": 2350,
-            "sell": 1645
+            "total": 2250,
+            "sell": 1575
           },
           "tags": [
             "Active",
@@ -11495,7 +11468,7 @@
             "8": false,
             "10": false,
             "11": true,
-            "12": false,
+            "12": true,
             "14": false
           },
           "stats": {
@@ -11562,12 +11535,12 @@
         },
         "3060": {
           "name": "Banner of Command",
-          "description": "<stats>+200 Health<br>+100% Base Health Regen <br>+60 Ability Power<br>+20 Magic Resist<br>+10% Cooldown Reduction</stats><br><br><aura>UNIQUE Aura - Legion:</aura> Grants nearby allies +15 Magic Resist.<br><active>UNIQUE Active - Promote:</active> Greatly increases the power of a lane minion and grants it immunity to magic damage (120 second cooldown).",
+          "description": "<stats>+60 Armor<br>+30 Magic Resist<br><mana>+400 Mana</mana><br>+10% Cooldown Reduction</stats><br><br><active>UNIQUE Active - Promote:</active> Greatly increases the power of a lane minion and grants it immunity to magic damage (120 second cooldown).",
           "colloq": ";flag",
           "plaintext": "Promotes a siege minion to a more powerful unit",
           "from": [
             "3105",
-            "3108"
+            "3024"
           ],
           "into": [],
           "image": {
@@ -11580,19 +11553,17 @@
             "h": 48
           },
           "gold": {
-            "base": 600,
+            "base": 100,
             "purchasable": true,
-            "total": 3000,
-            "sell": 2100
+            "total": 2200,
+            "sell": 1540
           },
           "tags": [
             "Active",
-            "Aura",
+            "Armor",
             "CooldownReduction",
-            "Health",
-            "HealthRegen",
-            "SpellBlock",
-            "SpellDamage"
+            "Mana",
+            "SpellBlock"
           ],
           "maps": {
             "1": false,
@@ -11603,16 +11574,16 @@
             "14": false
           },
           "stats": {
-            "FlatHPPoolMod": 200,
-            "FlatMagicDamageMod": 60,
-            "FlatSpellBlockMod": 20
+            "FlatMPPoolMod": 400,
+            "FlatArmorMod": 60,
+            "FlatSpellBlockMod": 30
           },
           "effect": {
             "Effect1Amount": "0.5",
             "Effect2Amount": "15",
             "Effect3Amount": "0.75"
           },
-          "depth": 4
+          "depth": 3
         },
         "3065": {
           "name": "Spirit Visage",
@@ -11675,7 +11646,6 @@
           ],
           "into": [
             "3187",
-            "3190",
             "3401",
             "3065",
             "3056",
@@ -11767,7 +11737,6 @@
         },
         "3069": {
           "name": "Talisman of Ascension",
-          "group": "GoldBase",
           "description": "<stats>+45 Armor<br>+150% Base Health Regen <br><mana>+75% Base Mana Regen <br></mana>+10% Cooldown Reduction</stats><br><br><unique>UNIQUE Passive - Point Runner:</unique> Builds up to +20% Movement Speed over 2 seconds while near turrets, fallen turrets and Void Gates.<br><unique>UNIQUE Passive - Favor:</unique> Being near a minion's death without dealing the killing blow grants 6 Gold and 10 Health.<br><active>UNIQUE Active:</active> Grants nearby allies +40% Movement Speed for 3 seconds (60 second cooldown).<br><br><groupLimit>Limited to 1 Gold Income Item.</groupLimit><br><br><rules><font color='#447777'>''Praise the sun.'' - Historian Shurelya, 22 September, 25 CLE</font></rules>",
           "colloq": ";shurelya;reverie",
           "plaintext": "Increases Health / Mana Regeneration and Cooldown Reduction. Activate to speed up nearby allies.",
@@ -11786,10 +11755,10 @@
             "h": 48
           },
           "gold": {
-            "base": 450,
+            "base": 350,
             "purchasable": true,
-            "total": 2500,
-            "sell": 1000
+            "total": 2400,
+            "sell": 960
           },
           "tags": [
             "Active",
@@ -12605,7 +12574,7 @@
         },
         "3090": {
           "name": "Wooglet's Witchcap",
-          "description": "<stats>+100 Ability Power<br>+45 Armor  </stats><br><br><unique>UNIQUE Passive:</unique> Increases Ability Power by 25%<br><active>UNIQUE Active:</active> Champion becomes invulnerable and untargetable for 2.5 seconds, but is unable to move, attack, cast spells, or use items during this time (90 second cooldown).",
+          "description": "<stats>+100 Ability Power<br>+45 Armor  </stats><br><br><unique>UNIQUE Passive:</unique> Increases Ability Power by 25%<br><active>UNIQUE Active:</active> Champion becomes invulnerable and untargetable for 2.5 seconds, but is unable to move, attack, cast spells, or use items during this time (120 second cooldown).",
           "colloq": ";hat",
           "plaintext": "Massively increases Ability Power and can be activated to enter stasis",
           "from": [
@@ -12648,7 +12617,7 @@
           "effect": {
             "Effect1Amount": "25",
             "Effect2Amount": "2.5",
-            "Effect3Amount": "90"
+            "Effect3Amount": "120"
           },
           "depth": 3
         },
@@ -12704,7 +12673,6 @@
         },
         "3092": {
           "name": "Frost Queen's Claim",
-          "group": "GoldBase",
           "description": "<stats>+50 Ability Power<br>+10% Cooldown Reduction<br>+2 Gold per 10 seconds<br><mana>+75% Base Mana Regen </mana></stats><br><br><unique>UNIQUE Passive - Tribute:</unique> Spells and basic attacks against champions or buildings deal 15 additional damage and grant 15 Gold. This can occur up to 3 times every 30 seconds.<br><active>UNIQUE Active:</active> Summon 2 icy ghosts for 6 seconds that seek out nearby enemy champions. Ghosts reveal enemies on contact and reduce their Movement Speed by 40% for between 2 and 5 seconds based on how far the ghosts have traveled (90 second cooldown).<br><br><groupLimit>Limited to 1 Gold Income Item.</groupLimit>",
           "colloq": "spooky ghosts;",
           "plaintext": "Sends out seeking wraiths that track hidden enemies and slow them",
@@ -12814,7 +12782,6 @@
         },
         "3096": {
           "name": "Nomad's Medallion",
-          "group": "GoldBase",
           "description": "<stats>+25% Base Health Regen <br><mana>+75% Base Mana Regen </mana><br>+10% Cooldown Reduction</stats><br><br><unique>UNIQUE Passive - Favor:</unique> Being near a minion's death without dealing the killing blow grants 6 Gold and 10 Health.<br><br><groupLimit>Limited to 1 Gold Income Item.</groupLimit><br><br><rules><font color='#447777'>''The medallion shines with the glory of a thousand voices when exposed to the sun.'' - Historian Shurelya, 22 June, 24 CLE</font></rules>",
           "colloq": ";",
           "plaintext": "Grants gold when nearby enemy minions die, Health Regen and Mana Regen",
@@ -12867,7 +12834,6 @@
         },
         "3097": {
           "name": "Targon's Brace",
-          "group": "GoldBase",
           "description": "<stats>+175 Health<br>+50% Base Health Regen <br>+2 Gold per 10 seconds </stats><br><br><unique>UNIQUE Passive - Spoils of War:</unique> Melee basic attacks execute minions below 200 (+10 per level) Health. Killing a minion heals the owner and the nearest allied champion for 40 Health and grants them kill Gold.<br><br>These effects require a nearby ally. Recharges every 30 seconds. Max 3 charges.<br><br><groupLimit>Limited to 1 Gold Income Item.</groupLimit>",
           "colloq": ";",
           "plaintext": "Periodically kill enemy minions to heal and grant gold to a nearby ally",
@@ -12923,7 +12889,6 @@
         },
         "3098": {
           "name": "Frostfang",
-          "group": "GoldBase",
           "description": "<stats>+15 Ability Power<br>+2 Gold per 10 seconds<br><mana>+75% Base Mana Regen </mana></stats><br><br><unique>UNIQUE Passive - Tribute:</unique> Spells and basic attacks against champions or buildings deal 15 additional damage and grant 15 Gold. This can occur up to 3 times every 30 seconds. Killing a minion disables this passive for 12 seconds.<br><br><groupLimit>Limited to 1 Gold Income Item.</groupLimit>",
           "colloq": ";",
           "plaintext": "Grants gold when you damage an enemy with a Spell or Attack",
@@ -13181,12 +13146,12 @@
         },
         "3105": {
           "name": "Aegis of the Legion",
-          "description": "<stats>+200 Health<br>+100% Base Health Regen <br>+20 Magic Resist</stats><br><br><aura>UNIQUE Aura - Legion:</aura> Grants nearby allies +10 Magic Resist.",
+          "description": "<stats>+30 Armor<br>+30 Magic Resist</stats>",
           "colloq": ";",
-          "plaintext": "Improves defenses for nearby allies",
+          "plaintext": "Grants Armor and Magic Resistance",
           "from": [
             "1033",
-            "3801"
+            "1029"
           ],
           "into": [
             "3190",
@@ -13202,15 +13167,13 @@
             "h": 48
           },
           "gold": {
-            "base": 400,
+            "base": 350,
             "purchasable": true,
-            "total": 1500,
-            "sell": 1050
+            "total": 1100,
+            "sell": 770
           },
           "tags": [
-            "Aura",
-            "Health",
-            "HealthRegen",
+            "Armor",
             "SpellBlock"
           ],
           "maps": {
@@ -13222,12 +13185,62 @@
             "14": false
           },
           "stats": {
-            "FlatHPPoolMod": 200,
-            "FlatSpellBlockMod": 20
+            "FlatArmorMod": 30,
+            "FlatSpellBlockMod": 30
+          },
+          "depth": 2
+        },
+        "3107": {
+          "name": "Redemption",
+          "description": "<stats>+400 Health<br>+75% Base Health Regen <br>+75% Base Mana Regen <br>+10% Cooldown Reduction</stats><br><br><passive>UNIQUE Passive:</passive> +10% Heal and Shield Power<br><active>UNIQUE Active:</active> Target an area within 5500 range. After 2.5 seconds, call down a beam of light to heal allies for 130 (+20 per level of target) Health, burn enemy champions for 10% of their maximum Health as <font color='#FFFFFF'>true</font> damage and deal 250 <font color='#FFFFFF'>true</font> damage to enemy minions (120 second cooldown).<br><br>Can be used while dead.<br><br><rules>(Half effect if the target has been affected by another Redemption recently.)</rules>",
+          "colloq": ";",
+          "plaintext": "Further improves defenses for nearby allies",
+          "from": [
+            "3114",
+            "3801"
+          ],
+          "into": [],
+          "image": {
+            "full": "3107.png",
+            "sprite": "item2.png",
+            "group": "item",
+            "x": 192,
+            "y": 192,
+            "w": 48,
+            "h": 48
+          },
+          "gold": {
+            "base": 650,
+            "purchasable": true,
+            "total": 2100,
+            "sell": 1470
+          },
+          "tags": [
+            "CooldownReduction",
+            "Health",
+            "HealthRegen",
+            "ManaRegen"
+          ],
+          "maps": {
+            "1": false,
+            "8": true,
+            "10": true,
+            "11": true,
+            "12": true,
+            "14": false
+          },
+          "stats": {
+            "FlatHPPoolMod": 400
           },
           "effect": {
-            "Effect1Amount": "10",
-            "Effect2Amount": "0.75"
+            "Effect1Amount": "0.1",
+            "Effect2Amount": "130",
+            "Effect3Amount": "20",
+            "Effect4Amount": "0.1",
+            "Effect5Amount": "250",
+            "Effect6Amount": "120",
+            "Effect7Amount": "550",
+            "Effect8Amount": "5500"
           },
           "depth": 3
         },
@@ -13244,7 +13257,6 @@
             "3092",
             "3115",
             "3165",
-            "3060",
             "3001",
             "3157"
           ],
@@ -13283,6 +13295,62 @@
           },
           "depth": 2
         },
+        "3109": {
+          "name": "Knight's Vow",
+          "description": "<stats>+400 Health<br>+100% Base Health Regen <br>+20 Armor</stats><br><br><active>UNIQUE Active:</active> Designate an allied champion as your <a href='KnightsVowPartner'>Partner</a> (90 second cooldown).<br><passive>UNIQUE Passive:</passive> If your <a href='KnightsVowPartner'>Partner</a> is nearby, gain +40 additional Armor and +15% Movement Speed towards them.<br><passive>UNIQUE Passive:</passive> If your <a href='KnightsVowPartner'>Partner</a> is nearby, heal for 12% of the damage your <a href='KnightsVowPartner'>Partner</a> deals to champions and redirect 12% of the damage your <a href='KnightsVowPartner'>Partner</a> takes from champions to you as <font color='#FFFFFF'>true</font> damage (healing and damage redirection are reduced by 50% if you are ranged).<br><br><rules>(Champions can only be linked by one Knight's Vow at a time.)</rules>",
+          "colloq": ";",
+          "plaintext": "Partner with an ally to protect each other",
+          "from": [
+            "3801",
+            "1029",
+            "3801"
+          ],
+          "into": [],
+          "image": {
+            "full": "3109.png",
+            "sprite": "item2.png",
+            "group": "item",
+            "x": 240,
+            "y": 192,
+            "w": 48,
+            "h": 48
+          },
+          "gold": {
+            "base": 800,
+            "purchasable": true,
+            "total": 2400,
+            "sell": 1680
+          },
+          "tags": [
+            "Armor",
+            "Aura",
+            "Health",
+            "HealthRegen",
+            "NonbootsMovement"
+          ],
+          "maps": {
+            "1": false,
+            "8": true,
+            "10": true,
+            "11": true,
+            "12": true,
+            "14": false
+          },
+          "stats": {
+            "FlatHPPoolMod": 400,
+            "FlatArmorMod": 20
+          },
+          "effect": {
+            "Effect1Amount": "40",
+            "Effect2Amount": "0.15",
+            "Effect3Amount": "0.12",
+            "Effect4Amount": "0.12",
+            "Effect5Amount": "90",
+            "Effect6Amount": "0.5",
+            "Effect7Amount": "900"
+          },
+          "depth": 3
+        },
         "3110": {
           "name": "Frozen Heart",
           "description": "<stats>+90 Armor<br>+20% Cooldown Reduction<br><mana>+400 Mana</mana></stats><br><br><aura>UNIQUE Aura:</aura> Reduces the Attack Speed of nearby enemies by 15%.",
@@ -13303,10 +13371,10 @@
             "h": 48
           },
           "gold": {
-            "base": 800,
+            "base": 700,
             "purchasable": true,
-            "total": 2800,
-            "sell": 1960
+            "total": 2700,
+            "sell": 1890
           },
           "tags": [
             "Armor",
@@ -13334,7 +13402,6 @@
         },
         "3111": {
           "name": "Mercury's Treads",
-          "group": "BootsUpgrades",
           "description": "<stats>+25 Magic Resist</stats><br><br><unique>UNIQUE Passive - Enhanced Movement:</unique> +45 Movement Speed<br><unique>UNIQUE Passive - Tenacity:</unique> Reduces the duration of stuns, slows, taunts, fears, silences, blinds, polymorphs, and immobilizes by 30%.",
           "colloq": ";",
           "plaintext": "Increases Movement Speed and reduces duration of disabling effects",
@@ -13382,7 +13449,6 @@
         },
         "3112": {
           "name": "Guardian's Orb",
-          "group": "GuardianItems",
           "description": "<stats>+150 Health<br>+30 Ability Power<br><mana>+10 Mana regen per 5 seconds</mana></stats><br><br><groupLimit>Limited to 1 Guardian's Item.</groupLimit>",
           "colloq": ";",
           "plaintext": "Good starting item for mages",
@@ -13477,7 +13543,7 @@
         },
         "3114": {
           "name": "Forbidden Idol",
-          "description": "<stats><mana>+50% Base Mana Regen </mana></stats><br><br><unique>UNIQUE Passive:</unique> +10% Cooldown Reduction<br><unique>UNIQUE Passive:</unique> +10% Heal and Shield Power",
+          "description": "<stats><mana>+50% Base Mana Regen </mana></stats><br><br><unique>UNIQUE Passive:</unique> +10% Cooldown Reduction<br><unique>UNIQUE Passive:</unique> +8% Heal and Shield Power",
           "colloq": ";",
           "plaintext": "Increases Mana Regeneration and Cooldown Reduction",
           "from": [
@@ -13485,6 +13551,7 @@
             "1004"
           ],
           "into": [
+            "3107",
             "3222",
             "3504"
           ],
@@ -13498,10 +13565,10 @@
             "h": 48
           },
           "gold": {
-            "base": 600,
+            "base": 550,
             "purchasable": true,
-            "total": 850,
-            "sell": 595
+            "total": 800,
+            "sell": 560
           },
           "tags": [
             "CooldownReduction",
@@ -13518,7 +13585,7 @@
           "stats": {},
           "effect": {
             "Effect1Amount": "-0.1",
-            "Effect2Amount": "0.1"
+            "Effect2Amount": "0.08"
           },
           "depth": 2
         },
@@ -13622,7 +13689,6 @@
         },
         "3117": {
           "name": "Boots of Mobility",
-          "group": "BootsUpgrades",
           "description": "<unique>UNIQUE Passive - Enhanced Movement:</unique> +25 Movement Speed. Increases to +115 Movement Speed when out of combat for 5 seconds.",
           "colloq": ";",
           "plaintext": "Greatly enhances Movement Speed when out of combat",
@@ -13843,6 +13909,7 @@
             "1412",
             "3071",
             "3104",
+            "3156",
             "3508",
             "3671",
             "3812"
@@ -13884,9 +13951,9 @@
         },
         "3134": {
           "name": "Serrated Dirk",
-          "description": "<stats>+20 Attack Damage</stats><br><br><unique>UNIQUE Passive:</unique> +10 <a href='FlatArmorPen'>Armor Penetration</a><br><unique>UNIQUE Passive:</unique> After killing any unit, your next basic attack or single target spell deals +15 damage.",
-          "colloq": ";",
-          "plaintext": "Increases Attack Damage and Armor Penetration",
+          "description": "<stats>+25 Attack Damage</stats><br><br><unique>UNIQUE Passive:</unique> +10 <a href='Lethality'>Lethality</a><br><unique>UNIQUE Passive:</unique> +20 Movement Speed out of Combat.",
+          "colloq": ";lethality",
+          "plaintext": "Increases Attack Damage and Lethality",
           "stacks": 0,
           "from": [
             "1036",
@@ -13895,7 +13962,7 @@
           "into": [
             "3142",
             "3147",
-            "3156"
+            "3814"
           ],
           "image": {
             "full": "3134.png",
@@ -13914,7 +13981,8 @@
           },
           "tags": [
             "ArmorPenetration",
-            "Damage"
+            "Damage",
+            "NonbootsMovement"
           ],
           "maps": {
             "1": false,
@@ -13925,11 +13993,12 @@
             "14": false
           },
           "stats": {
-            "FlatPhysicalDamageMod": 20
+            "FlatPhysicalDamageMod": 25
           },
           "effect": {
-            "Effect1Amount": "15",
-            "Effect2Amount": "10"
+            "Effect1Amount": "0",
+            "Effect2Amount": "10",
+            "Effect3Amount": "20"
           },
           "depth": 2
         },
@@ -14181,9 +14250,9 @@
         },
         "3142": {
           "name": "Youmuu's Ghostblade",
-          "description": "<stats>+60 Attack Damage<br>+10% Cooldown Reduction</stats><br><br><unique>UNIQUE Passive:</unique> +20 <a href='FlatArmorPen'>Armor Penetration</a><br><active>UNIQUE Active:</active> Grants +20% Movement Speed and +40% Attack Speed for 6 seconds (45 second cooldown).",
-          "colloq": ";",
-          "plaintext": "Activate to greatly increase Movement Speed and Attack Speed",
+          "description": "<stats>+60 Attack Damage<br>+10% Cooldown Reduction</stats><br><br><unique>UNIQUE Passive:</unique> +20 <a href='Lethality'>Lethality</a><br><unique>UNIQUE Passive:</unique> +20 Movement Speed out of Combat<br><active>UNIQUE Active:</active> Grants +20% Movement Speed for 6 seconds (45 second cooldown).",
+          "colloq": ";lethality",
+          "plaintext": "Activate to greatly increase Movement Speed",
           "from": [
             "3133",
             "3134"
@@ -14199,15 +14268,14 @@
             "h": 48
           },
           "gold": {
-            "base": 1000,
+            "base": 700,
             "purchasable": true,
-            "total": 3200,
-            "sell": 2240
+            "total": 2900,
+            "sell": 2030
           },
           "tags": [
             "Active",
             "ArmorPenetration",
-            "AttackSpeed",
             "CooldownReduction",
             "Damage",
             "NonbootsMovement"
@@ -14227,8 +14295,9 @@
             "Effect1Amount": "45",
             "Effect2Amount": "20",
             "Effect3Amount": "0.2",
-            "Effect4Amount": "0.4",
-            "Effect5Amount": "6"
+            "Effect4Amount": "0",
+            "Effect5Amount": "6",
+            "Effect6Amount": "20"
           },
           "depth": 3
         },
@@ -14339,7 +14408,7 @@
         },
         "3145": {
           "name": "Hextech Revolver",
-          "description": "<stats>+40 Ability Power</stats><br><br><unique>UNIQUE Passive - Magic Bolt:</unique> Damaging an enemy champion with a basic attack shocks them for <levelScale>75 - 150</levelScale> bonus magic damage (40 second cooldown, shared with other <font color='#9999FF'><a href='itembolt'>Hextech</a></font> items).<br><br>Magic Bolt's cooldown is reduced by Active Item cooldown reduction.<br><br><rules>(Damage scales based on level. Hextech effects can trigger other item spell effects.)</rules>",
+          "description": "<stats>+40 Ability Power</stats><br><br><unique>UNIQUE Passive - Magic Bolt:</unique> Damaging an enemy champion with a basic attack shocks them for <levelScale>50 - 125</levelScale> bonus magic damage (40 second cooldown, shared with other <font color='#9999FF'><a href='itembolt'>Hextech</a></font> items).<br><br>Magic Bolt's cooldown is reduced by Active Item cooldown reduction.<br><br><rules>(Damage scales based on level. Hextech effects can trigger other item spell effects.)</rules>",
           "colloq": ";",
           "plaintext": "Increases Ability Power. Deal bonus magic damage on attack periodically.",
           "from": [
@@ -14382,9 +14451,9 @@
           },
           "effect": {
             "Effect1Amount": "0",
-            "Effect2Amount": "75",
+            "Effect2Amount": "50",
             "Effect3Amount": "0",
-            "Effect4Amount": "150",
+            "Effect4Amount": "125",
             "Effect5Amount": "40"
           },
           "depth": 2
@@ -14443,9 +14512,9 @@
         },
         "3147": {
           "name": "Duskblade of Draktharr",
-          "description": "<stats>+75 Attack Damage<br>+5% Movement Speed</stats><br><br><unique>UNIQUE Passive:</unique> +10 <a href='FlatArmorPen'>Armor Penetration</a><br><unique>UNIQUE Passive:</unique> Basic Attacks on an enemy champion apply <unlockedPassive>Nightfall</unlockedPassive> (120 second cooldown).<br><br><unlockedPassive>Nightfall:</unlockedPassive> After 2 seconds, deal physical damage equal to 90 plus 25% of the target's missing health. If you get a kill or assist on the target before Nightfall ends, the cooldown is refunded.",
-          "colloq": ";",
-          "plaintext": "Deals a delayed burst of damage on hit.",
+          "description": "<stats>+65 Attack Damage</stats><br><br><unique>UNIQUE Passive:</unique> +15 <a href='Lethality'>Lethality</a><br><unique>UNIQUE Passive:</unique> +20 Movement Speed out of Combat.<br><unique>UNIQUE Passive - Nightstalker:</unique> After being unseen for at least 1 second, your next Basic Attack against an enemy champion will deal 50 (+200% Lethality) true damage on-hit (lasts for 4 seconds after being seen by an enemy champion).<br><unique>UNIQUE Passive - Blackout:</unique> When spotted by an enemy ward, causes a blackout for 8 seconds, disabling all nearby enemy wards (90 second cooldown).",
+          "colloq": ";lethality",
+          "plaintext": "Deals additional true damage on-hit and provides true sight periodically",
           "from": [
             "3134",
             "1038"
@@ -14481,17 +14550,15 @@
             "14": false
           },
           "stats": {
-            "FlatPhysicalDamageMod": 75,
-            "PercentMovementSpeedMod": 0.05
+            "FlatPhysicalDamageMod": 65
           },
           "effect": {
-            "Effect1Amount": "10",
-            "Effect2Amount": "0",
-            "Effect3Amount": "2",
-            "Effect4Amount": "0.25",
-            "Effect5Amount": "120",
-            "Effect6Amount": "60",
-            "Effect7Amount": "90"
+            "Effect1Amount": "15",
+            "Effect2Amount": "20",
+            "Effect3Amount": "0",
+            "Effect4Amount": "90",
+            "Effect5Amount": "50",
+            "Effect6Amount": "2"
           },
           "depth": 3
         },
@@ -14549,7 +14616,7 @@
         },
         "3152": {
           "name": "Hextech Protobelt-01",
-          "description": "<stats>+300 Health<br>+60 Ability Power<br>+10% Cooldown Reduction</stats><br><br><unique>UNIQUE Active - Fire Bolt:</unique> Dash forward and unleash a nova of fire bolts that deal <levelScale>75 - 150</levelScale> (+35% of your Ability Power) as magic damage (40 second cooldown, shared with other <font color='#9999FF'><a href='itembolt'>Hextech</a></font> items).<br><br>Champions and Monsters hit by multiple fire bolts take 20% damage per additional bolt.<br><br><rules>(This dash cannot pass through terrain.)</rules>",
+          "description": "<stats>+300 Health<br>+60 Ability Power<br>+10% Cooldown Reduction</stats><br><br><unique>UNIQUE Active - Fire Bolt:</unique> Dash forward and unleash a nova of fire bolts that deal <levelScale>75 - 150</levelScale> (+25% of your Ability Power) as magic damage (40 second cooldown, shared with other <font color='#9999FF'><a href='itembolt'>Hextech</a></font> items).<br><br>Champions and Monsters hit by multiple fire bolts take 10% damage per additional bolt.<br><br><rules>(This dash cannot pass through terrain.)</rules>",
           "colloq": "rocket belt;",
           "plaintext": "Activate to dash forward and unleash a fiery explosion",
           "from": [
@@ -14596,8 +14663,8 @@
             "Effect3Amount": "40",
             "Effect4Amount": "75",
             "Effect5Amount": "150",
-            "Effect6Amount": "0.2",
-            "Effect7Amount": "0.35",
+            "Effect6Amount": "0.1",
+            "Effect7Amount": "0.25",
             "Effect8Amount": "40"
           },
           "depth": 3
@@ -14710,13 +14777,13 @@
         },
         "3156": {
           "name": "Maw of Malmortius",
-          "description": "<stats>+55 Attack Damage<br>+40 Magic Resist<br>+10 <a href='FlatArmorPen'>Armor Penetration</a></stats><br><br><unique>UNIQUE Passive - Lifeline:</unique> Upon taking magic damage that would reduce Health below 30%, grants a shield that absorbs magic damage equal to 300 + 1 per bonus Magic Resistance for 5 seconds (90 second cooldown).<br><unlockedPassive>Lifegrip:</unlockedPassive> When <i>Lifeline</i> triggers, gain +10% Spell Vamp and +10% Life Steal until out of combat.",
+          "description": "<stats>+50 Attack Damage<br>+45 Magic Resist<br>+10% Cooldown Reduction</stats><br><br><unique>UNIQUE Passive - Lifeline:</unique> Upon taking magic damage that would reduce Health below 30%, grants a shield that absorbs magic damage equal to 300 + 1 per bonus Magic Resistance for 5 seconds (90 second cooldown).<br><unlockedPassive>Lifegrip:</unlockedPassive> When <i>Lifeline</i> triggers, gain +20 Attack Damage, +10% Spell Vamp and +10% Life Steal until out of combat.",
           "colloq": ";",
           "plaintext": "Grants bonus Attack Damage when Health is low",
           "stacks": 0,
           "from": [
             "3155",
-            "3134"
+            "3133"
           ],
           "into": [],
           "image": {
@@ -14735,7 +14802,7 @@
             "sell": 2275
           },
           "tags": [
-            "ArmorPenetration",
+            "CooldownReduction",
             "Damage",
             "LifeSteal",
             "SpellBlock",
@@ -14750,8 +14817,8 @@
             "14": false
           },
           "stats": {
-            "FlatPhysicalDamageMod": 55,
-            "FlatSpellBlockMod": 40
+            "FlatPhysicalDamageMod": 50,
+            "FlatSpellBlockMod": 45
           },
           "effect": {
             "Effect1Amount": "1",
@@ -14760,7 +14827,7 @@
             "Effect4Amount": "300",
             "Effect5Amount": "5",
             "Effect6Amount": "90",
-            "Effect7Amount": "0",
+            "Effect7Amount": "20",
             "Effect8Amount": "0"
           },
           "depth": 3
@@ -14817,7 +14884,6 @@
         },
         "3158": {
           "name": "Ionian Boots of Lucidity",
-          "group": "BootsUpgrades",
           "description": "<unique>UNIQUE Passive:</unique> +10% Cooldown Reduction<br><unique>UNIQUE Passive - Enhanced Movement:</unique> +45 Movement Speed<br><unique>UNIQUE Passive:</unique> Reduces Summoner Spell cooldowns by 10%<br><br><br><rules><font color='#FDD017'>''This item is dedicated in honor of Ionia's victory over Noxus in the Rematch for the Southern Provinces on 10 December, 20 CLE.''</font></rules>",
           "colloq": ";",
           "plaintext": "Increases Movement Speed and Cooldown Reduction",
@@ -14964,7 +15030,7 @@
         },
         "3174": {
           "name": "Athene's Unholy Grail",
-          "description": "<stats>+40 Ability Power<br>+25 Magic Resist<br>+20% Cooldown Reduction<br><mana>+75% Base Mana Regen </mana></stats><br><br><unique>UNIQUE Passive:</unique> Gain 20% of the <a href='premitigation'><font color='#6666FF'><u>premitigation</u></font></a> damage dealt to champions as Blood Charges, up to <levelScale>100 - 250</levelScale>  max. Healing or shielding another ally consumes charges to heal them, up to the original effect amount.<br><unique>UNIQUE Passive:</unique> Increases Base Health Regeneration by 100% if current Health % is lower than current Mana %. <mana>Increases Base Mana Regeneration by 100% if current Mana % is lower than current Health %.</mana><br><br><rules>(Maximum amount of Blood Charges stored is based on level. Healing amplification is applied to the total heal value.)</rules>",
+          "description": "<stats>+40 Ability Power<br>+25 Magic Resist<br>+20% Cooldown Reduction<br><mana>+75% Base Mana Regen </mana></stats><br><br><unique>UNIQUE Passive:</unique> Gain 20% of the <a href='premitigation'><font color='#6666FF'><u>premitigation</u></font></a> damage dealt to champions as Blood Charges, up to <levelScale>100 - 250</levelScale>  max. Healing or shielding another ally consumes charges to heal them, up to the original effect amount.<br><unique>UNIQUE Passive - Harmony:</unique> Grants bonus % Base Health Regen equal to your bonus % Base Mana Regen.<br><br><rules>(Maximum amount of Blood Charges stored is based on level. Healing amplification is applied to the total heal value.)</rules>",
           "colloq": ";",
           "plaintext": "Deal damage to empower your heals and shields",
           "from": [
@@ -14982,10 +15048,10 @@
             "h": 48
           },
           "gold": {
-            "base": 450,
+            "base": 400,
             "purchasable": true,
-            "total": 2250,
-            "sell": 1575
+            "total": 2100,
+            "sell": 1470
           },
           "tags": [
             "CooldownReduction",
@@ -15069,7 +15135,6 @@
         },
         "3184": {
           "name": "Guardian's Hammer",
-          "group": "GuardianItems",
           "description": "<stats>+150 Health<br>+15 Attack Damage<br>+10% Life Steal</stats><br><br><groupLimit>Limited to 1 Guardian's Item.</groupLimit>",
           "colloq": ";dblade",
           "plaintext": "Good starting item for attackers",
@@ -15223,12 +15288,12 @@
         },
         "3190": {
           "name": "Locket of the Iron Solari",
-          "description": "<stats>+400 Health<br>+100% Base Health Regen <br>+20 Magic Resist<br>+10% Cooldown Reduction</stats><br><br><active>UNIQUE Active:</active> Grants a shield to nearby allies for 2 seconds that absorbs up to 75 (+15 per level) damage (60 second cooldown). This shielding is halved for units recently shielded this way.<br><aura>UNIQUE Aura - Legion:</aura> Grants nearby allies +15 Magic Resist.",
+          "description": "<stats>+30 Armor<br>+60 Magic Resist</stats><br><br><active>UNIQUE Active:</active> Grants a decaying shield to nearby allies for 2.5 seconds that absorbs up to 35 (+35 per level) damage (90 second cooldown).<br><br><rules>(Half effect if the target has been affected by another Locket of the Iron Solari recently.)</rules>",
           "colloq": ";",
           "plaintext": "Activate to shield nearby allies from damage",
           "from": [
             "3105",
-            "3067"
+            "1033"
           ],
           "into": [],
           "image": {
@@ -15241,17 +15306,14 @@
             "h": 48
           },
           "gold": {
-            "base": 200,
+            "base": 650,
             "purchasable": true,
-            "total": 2500,
-            "sell": 1750
+            "total": 2200,
+            "sell": 1540
           },
           "tags": [
             "Active",
-            "Aura",
-            "CooldownReduction",
-            "Health",
-            "HealthRegen",
+            "Armor",
             "SpellBlock"
           ],
           "maps": {
@@ -15263,18 +15325,18 @@
             "14": false
           },
           "stats": {
-            "FlatHPPoolMod": 400,
-            "FlatSpellBlockMod": 20
+            "FlatArmorMod": 30,
+            "FlatSpellBlockMod": 60
           },
           "effect": {
-            "Effect1Amount": "15",
+            "Effect1Amount": "0",
             "Effect2Amount": "0.75",
-            "Effect3Amount": "2",
-            "Effect4Amount": "75",
-            "Effect5Amount": "15",
-            "Effect6Amount": "60"
+            "Effect3Amount": "2.5",
+            "Effect4Amount": "35",
+            "Effect5Amount": "35",
+            "Effect6Amount": "90"
           },
-          "depth": 4
+          "depth": 3
         },
         "3191": {
           "name": "Seeker's Armguard",
@@ -15558,7 +15620,7 @@
         },
         "3222": {
           "name": "Mikael's Crucible",
-          "description": "<stats>+35 Magic Resist<br>+10% Cooldown Reduction<br><mana>+150% Base Mana Regen </mana></stats><br><br><unique>UNIQUE Passive:</unique> +15% Heal and Shield Power<br><unique>UNIQUE Passive:</unique> Increases Base Health Regeneration by 100% if current Health % is lower than current Mana %. <mana>Increases Base Mana Regeneration by 100% if current Mana % is lower than current Health %.</mana><br><active>UNIQUE Active:</active> Removes all stuns, roots, taunts, fears, silences, and slows on an allied champion and heals that champion for 150 (+10% of maximum Health) (180 second cooldown).",
+          "description": "<stats>+35 Magic Resist<br>+10% Cooldown Reduction<br><mana>+150% Base Mana Regen </mana></stats><br><br><unique>UNIQUE Passive:</unique> +20% Heal and Shield Power<br><unique>UNIQUE Passive - Harmony:</unique> Grants bonus % Base Health Regen equal to your bonus % Base Mana Regen.<br><active>UNIQUE Active:</active> Cleanses all stuns, roots, taunts, fears, silences, and slows on an allied champion and grants them slow immunity for 2 seconds (120 second cooldown).<br><br>Successfully cleansing an effect this way grants the ally 40% movement speed for 2 seconds.",
           "colloq": ";",
           "plaintext": "Activate to heal and remove all disabling effects from an allied champion",
           "from": [
@@ -15576,10 +15638,10 @@
             "h": 48
           },
           "gold": {
-            "base": 650,
+            "base": 500,
             "purchasable": true,
-            "total": 2400,
-            "sell": 1680
+            "total": 2100,
+            "sell": 1470
           },
           "tags": [
             "Active",
@@ -15610,6 +15672,54 @@
             "Effect8Amount": "1"
           },
           "depth": 3
+        },
+        "3252": {
+          "name": "Poacher's Dirk",
+          "description": "<stats>+15 Attack Damage</stats><br><br><unique>UNIQUE Passive:</unique> +20 Movement Speed out of Combat<br><unique>UNIQUE Passive:</unique> After poaching 3 large monsters from the enemy jungle (60 second cooldown), transforms into a Serrated Dirk.",
+          "colloq": ";serrated dirk;lethality",
+          "plaintext": "Transforms into a Serrated Dirk after poaching in the enemy jungle.",
+          "stacks": 0,
+          "from": [
+            "1036"
+          ],
+          "into": [],
+          "image": {
+            "full": "3252.png",
+            "sprite": "item2.png",
+            "group": "item",
+            "x": 288,
+            "y": 192,
+            "w": 48,
+            "h": 48
+          },
+          "gold": {
+            "base": 400,
+            "purchasable": true,
+            "total": 750,
+            "sell": 525
+          },
+          "tags": [
+            "ArmorPenetration",
+            "Damage",
+            "NonbootsMovement"
+          ],
+          "maps": {
+            "1": false,
+            "8": false,
+            "10": true,
+            "11": true,
+            "12": false,
+            "14": false
+          },
+          "stats": {
+            "FlatPhysicalDamageMod": 15
+          },
+          "effect": {
+            "Effect1Amount": "100",
+            "Effect2Amount": "15",
+            "Effect3Amount": "20"
+          },
+          "depth": 2
         },
         "3285": {
           "name": "Luden's Echo",
@@ -15665,7 +15775,6 @@
         },
         "3301": {
           "name": "Ancient Coin",
-          "group": "GoldBase",
           "description": "<stats><mana>+25% Base Mana Regen </mana><br>+5% Cooldown Reduction</stats><br><br><unique>UNIQUE Passive - Favor:</unique> Being near a minion's death without dealing the killing blow grants 4 Gold and 5 Health.<br><br><groupLimit>Limited to 1 Gold Income Item.</groupLimit><br><br><i><font color='#447777'>''Gold dust rises from the desert and clings to the coin.'' - Historian Shurelya, 11 November, 23 CLE</font></i>",
           "colloq": ";",
           "plaintext": "Grants gold when nearby minions die that you didn't kill",
@@ -15709,7 +15818,6 @@
         },
         "3302": {
           "name": "Relic Shield",
-          "group": "GoldBase",
           "description": "<stats>+75 Health<br>+2 Gold per 10 seconds </stats><br><br><unique>UNIQUE Passive - Spoils of War:</unique> Melee basic attacks execute minions below 195 (+5 per level) Health. Killing a minion heals the owner and the nearest allied champion for 15 Health and grants them kill Gold.<br><br>These effects require a nearby ally. Recharges every 40 seconds. Max 2 charges. <br><br><groupLimit>Limited to 1 Gold Income Item.</groupLimit>",
           "colloq": ";",
           "plaintext": "Kill minions periodically to heal and grant gold to a nearby ally",
@@ -15757,7 +15865,6 @@
         },
         "3303": {
           "name": "Spellthief's Edge",
-          "group": "GoldBase",
           "description": "<stats>+5 Ability Power<br>+2 Gold per 10 seconds<br><mana>+25% Base Mana Regen </mana></stats><br><br><unique>UNIQUE Passive - Tribute:</unique> Spells and basic attacks against champions or buildings deal 10 additional damage and grant 8 Gold. This can occur up to 3 times every 30 seconds. Killing a minion disables this passive for 12 seconds.<br><br><groupLimit>Limited to 1 Gold Income Item.</groupLimit>",
           "colloq": ";",
           "plaintext": "Grants gold when you attack enemies",
@@ -15807,7 +15914,6 @@
         },
         "3340": {
           "name": "Warding Totem (Trinket)",
-          "group": "RelicBase",
           "description": "<groupLimit>Limited to 1 Trinket.</groupLimit><br><br><active>Active:</active> Consume a charge to place an invisible <font color='#BBFFFF'>Stealth Ward</font> which reveals the surrounding area for <levelScale>60 - 120</levelScale> seconds. <br><br>Stores one charge every <levelScale>180 - 90</levelScale> seconds, up to 2 maximum charges.<br><br>Ward duration and recharge time gradually improve with level.<br><br><rules>(Limit 3 <font color='#BBFFFF'>Stealth Wards</font> on the map per player. Switching to a <font color='#BBFFFF'>Lens</font> type trinket will disable <font color='#BBFFFF'>Trinket</font> use for 120 seconds.)</rules>",
           "colloq": "yellow;",
           "plaintext": "Periodically place a Stealth Ward",
@@ -15856,7 +15962,6 @@
         },
         "3341": {
           "name": "Sweeping Lens (Trinket)",
-          "group": "RelicBase",
           "description": "<groupLimit>Limited to 1 Trinket.</groupLimit><br><br><active>Active:</active> Scans an area for 6 seconds, warning against hidden hostile units and revealing / disabling invisible traps and wards (90 to 60 second cooldown).<br><br>Cast range and sweep radius gradually improve with level.<br><br><rules>(Switching to a <font color='#BBFFFF'>Totem</font>-type trinket will disable <font color='#BBFFFF'>Trinket</font> use for 120 seconds.)</rules>",
           "colloq": "red;",
           "plaintext": "Detects and disables nearby invisible wards and traps",
@@ -15904,7 +16009,6 @@
         },
         "3345": {
           "name": "Soul Anchor (Trinket)",
-          "group": "RelicBase",
           "description": "<groupLimit>Limited to 1 Trinket.</groupLimit><br><br><active>Active:</active> Consumes a charge to instantly revive at your Summoner Platform and grants 125% Movement Speed that decays over 12 seconds.<br><br><rules>Additional charges are gained at levels 9 and 14.</rules><br><br><font color='#BBFFFF'>(Max: 2 charges)</font></rules><br><br>",
           "colloq": "",
           "plaintext": "Consumes charge to revive champion.",
@@ -15942,7 +16046,6 @@
         },
         "3348": {
           "name": "Arcane Sweeper",
-          "group": "RelicBase",
           "description": "<active>UNIQUE Active - Hunter's Sight:</active> A stealth-detecting mist grants vision in the target area for 5 seconds, revealing traps and enemy champions that enter for 3 seconds (90 second cooldown).",
           "colloq": ";",
           "plaintext": "Activate to reveal a nearby area of the map",
@@ -15989,7 +16092,6 @@
         },
         "3361": {
           "name": "Greater Stealth Totem (Trinket)",
-          "group": "RelicBase",
           "description": "<groupLimit>Limited to 1 Trinket.</groupLimit><levelLimit> *Level 9+ required to upgrade.</levelLimit><stats></stats><br><br><unique>UNIQUE Active:</unique> Consume a charge to place an invisible ward that reveals the surrounding area for 180 seconds.  Stores a charge every 60 seconds, up to 2 total. Limit 3 <font color='#BBFFFF'>Stealth Wards</font> on the map per player.<br><br><rules>(Trinkets cannot be used in the first 30 seconds of a game. Selling a Trinket will disable Trinket use for 120 seconds).</rules>",
           "colloq": "yellow;",
           "plaintext": "Periodically place a Stealth Ward",
@@ -16037,7 +16139,6 @@
         },
         "3362": {
           "name": "Greater Vision Totem (Trinket)",
-          "group": "RelicBase",
           "description": "<groupLimit>Limited to 1 Trinket.</groupLimit><levelLimit> *Level 9+ required to upgrade.</levelLimit><stats></stats><br><br><unique>UNIQUE Active:</unique> Places a visible ward that reveals the surrounding area and invisible units in the area until killed (120 second cooldown). Limit 1 <font color='#BBFFFF'>Vision Ward</font> on the map per player.<br><br><rules>(Trinkets cannot be used in the first 30 seconds of a game. Selling a Trinket will disable Trinket use for 120 seconds).</rules>",
           "colloq": "yellow;",
           "plaintext": "Periodically place a Vision Ward",
@@ -16085,7 +16186,6 @@
         },
         "3363": {
           "name": "Farsight Alteration",
-          "group": "RelicBase",
           "description": "<levelLimit>* Level 9+ required to upgrade.</levelLimit><br><br>Alters the <font color='#FFFFFF'>Warding Totem</font> Trinket:<br><br><stats><font color='#00FF00'>+</font> Massively increased cast range (+650%)<br><font color='#00FF00'>+</font> Infinite duration and does not count towards ward limit<br><font color='#FF0000'>-</font> <font color='#FF6600'>10% increased cooldown</font><br><font color='#FF0000'>-</font> <font color='#FF6600'>Ward is visible, fragile, untargetable by allies</font><br><font color='#FF0000'>-</font> <font color='#FF6600'>45% reduced ward vision radius</font><br><font color='#FF0000'>-</font> <font color='#FF6600'>Cannot store charges</font></stats>",
           "colloq": "blue; totem;",
           "plaintext": "Grants increased range and reveals the targetted area",
@@ -16132,7 +16232,6 @@
         },
         "3364": {
           "name": "Oracle Alteration",
-          "group": "RelicBase",
           "description": "<levelLimit>* Level 9+ required to upgrade.</levelLimit><stats></stats><br><br>Alters the <font color='#FFFFFF'>Sweeping Lens</font> Trinket:<br><br><stats><font color='#00FF00'>+</font> Increased detection radius<br><font color='#00FF00'>+</font> Sweeping effect follows you for 10 seconds<br><font color='#FF0000'>-</font> <font color='#FF6600'>Cast range reduced to zero</font></stats>",
           "colloq": "red; lens;",
           "plaintext": "Disables nearby invisible wards and traps for a duration",
@@ -16179,8 +16278,7 @@
         },
         "3401": {
           "name": "Face of the Mountain",
-          "group": "GoldBase",
-          "description": "<stats>+450 Health<br>+100% Base Health Regen <br>+10% Cooldown Reduction<br>+2 Gold per 10 seconds </stats><br><br><unique>UNIQUE Passive - Spoils of War:</unique> Melee basic attacks execute minions below 320 (+20 per level) Health. Killing a minion heals the owner and the nearest allied champion for 50 Health and grants them kill Gold. These effects require a nearby ally. Recharges every 30 seconds. Max 4 charges.<br><unique>UNIQUE Active:</unique> Grant a shield to an ally equal to 10% of your maximum Health for 4 seconds. After 4 seconds, the shield explodes to slow nearby enemies by 40% for 2 seconds (60 second cooldown).<br><br><groupLimit>Limited to 1 Gold Income Item.</groupLimit>",
+          "description": "<stats>+450 Health<br>+100% Base Health Regen <br>+10% Cooldown Reduction<br>+2 Gold per 10 seconds </stats><br><br><unique>UNIQUE Passive - Spoils of War:</unique> Melee basic attacks execute minions below 320 (+20 per level) Health. Killing a minion heals the owner and the nearest allied champion for 50 Health and grants them kill Gold. These effects require a nearby ally. Recharges every 30 seconds. Max 4 charges.<br><unique>UNIQUE Active:</unique> Grant a shield to you and an ally equal to 10% of your maximum Health for 4 seconds. After 4 seconds, the shields explode to slow nearby enemies by 40% for 2 seconds (60 second cooldown).  Automatically targets the most wounded ally if cast upon self.<br><br><groupLimit>Limited to 1 Gold Income Item.</groupLimit>",
           "colloq": ";",
           "plaintext": "Shield an ally from damage based on your Health",
           "from": [
@@ -16235,7 +16333,6 @@
         },
         "3460": {
           "name": "Golden Transcendence",
-          "group": "RelicBase",
           "description": "<unique>Active:</unique> Use this trinket to teleport to one of the battle platforms. Can only be used from the summoning platform.<br><br><i><font color='#FDD017'>''It is at this magical precipice where a champion is dismantled, reforged, and empowered.''</font></i>",
           "colloq": ";",
           "plaintext": "",
@@ -16272,7 +16369,6 @@
         },
         "3461": {
           "name": "Golden Transcendence (Disabled)",
-          "group": "RelicBase",
           "description": "<unique>Active:</unique> Use this trinket to teleport to one of the battle platforms. Can only be used from the summoning platform.<br><br><i><font color='#FDD017'>''It is at this magical precipice where a champion is dismantled, reforged, and empowered.''</font></i>",
           "colloq": ";",
           "plaintext": "",
@@ -16309,7 +16405,6 @@
         },
         "3462": {
           "name": "Seer Stone (Trinket)",
-          "group": "RelicBase",
           "description": "<groupLimit>Limited to 1 Trinket.</groupLimit><br><br><active>Active:</active> Reveals a small area within <font color='#FFFFF'>2500</font> range for 3 seconds. Enemy champions will be revealed for 5 seconds (60 second cooldown)",
           "colloq": "blue;",
           "plaintext": "Briefly reveals a nearby targeted area",
@@ -16354,9 +16449,9 @@
         },
         "3504": {
           "name": "Ardent Censer",
-          "description": "<stats>+60 Ability Power<br>+10% Cooldown Reduction<br><mana>+50% Base Mana Regen </mana></stats><br><br><unique>UNIQUE Passive:</unique> +15% Heal and Shield Power<br><unique>UNIQUE Passive:</unique> +8% Movement Speed<br><unique>UNIQUE Passive:</unique> Your heals and shields on another allied champion grant them 15% Attack Speed and 30 magic damage on-hit for 6 seconds.<br><br><rules>(This does not include regeneration effects or effects on yourself.)</rules>",
+          "description": "<stats>+60 Ability Power<br>+10% Cooldown Reduction<br><mana>+50% Base Mana Regen </mana></stats><br><br><unique>UNIQUE Passive:</unique> +10% Heal and Shield Power<br><unique>UNIQUE Passive:</unique> +8% Movement Speed<br><unique>UNIQUE Passive:</unique> Your heals and shields on another allied champion grant them 20% Attack Speed and their attacks drain 20 health on-hit for 6 seconds.<br><br><rules>(This does not include regeneration effects or effects on yourself.)</rules>",
           "colloq": "",
-          "plaintext": "Shield and heal effects on other units grant them Attack Speed and bonus damage briefly",
+          "plaintext": "Shield and heal effects on other units grant them Attack Speed and their attacks drain life",
           "from": [
             "3114",
             "3113"
@@ -16372,10 +16467,10 @@
             "h": 48
           },
           "gold": {
-            "base": 700,
+            "base": 650,
             "purchasable": true,
-            "total": 2400,
-            "sell": 1680
+            "total": 2300,
+            "sell": 1610
           },
           "tags": [
             "CooldownReduction",
@@ -16396,10 +16491,10 @@
           },
           "effect": {
             "Effect1Amount": "0.08",
-            "Effect2Amount": "0.15",
+            "Effect2Amount": "0.2",
             "Effect3Amount": "6",
-            "Effect4Amount": "30",
-            "Effect5Amount": "0.15"
+            "Effect4Amount": "20",
+            "Effect5Amount": "0.1"
           },
           "depth": 3
         },
@@ -16515,7 +16610,6 @@
         },
         "3599": {
           "name": "The Black Spear",
-          "group": "TheBlackSpear",
           "description": "<stats></stats><br><active>Active:</active> Offer to bind with an ally for the remainder of the game, becoming Oathsworn Allies. Oathsworn empowers you both while near one another.",
           "colloq": ";spear",
           "plaintext": "Kalista's spear that binds an Oathsworn Ally.",
@@ -16584,7 +16678,6 @@
         },
         "3631": {
           "name": "Siege Ballista",
-          "group": "SiegeSniperCannonGroup",
           "description": "<br><font color='#FF9900'>Deploys a ballista that shoots the closest turret.</font><br><br>Places a long range ballista if within 2200 range of an enemy turret. After an 5 second delay, it will begin firing at the nearest enemy turret, dealing heavy damage. If the targeted turret expires, the ballista will as well.",
           "colloq": "",
           "plaintext": "Place a long range anti-turret ballista",
@@ -16705,7 +16798,6 @@
         },
         "3634": {
           "name": "Tower: Beam of Ruination",
-          "group": "SiegeLaserAffixGroup",
           "description": "<br><font color='#FF9900'>Attach, then recast to fire a damaging beam from a turret to your cursor.</font><br><br><font color='#FF9900'>First Cast:</font> Attach a Slayer Beam to the target turret that can be fired 3 times.<br></br><font color='#FF9900'>Next Three Casts:</font> Fires the attached beam towards your cursor, dealing 30/level + 30% of the hit target's maximum health (20% damage to minions) in magic damage to all targets in a line.<br></br><br></br>Beam will last 15 seconds, or until it has been fired 3 times.",
           "colloq": "",
           "plaintext": "Attaches a three shot beam to a turret which can then be aimed and fired",
@@ -16750,7 +16842,6 @@
         },
         "3635": {
           "name": "Port Pad",
-          "group": "SiegeTeleportPadGroup",
           "description": "<br><font color='#FF9900'>Deploy an additional teleport target.</font><br><br>Places a Port Pad at target location. After a 4 second delay, it activates, allowing you or your allies to teleport to it from base.",
           "colloq": "",
           "plaintext": "Creates another point for your team to Teleport to",
@@ -16791,7 +16882,6 @@
         },
         "3636": {
           "name": "Tower: Storm Bulwark",
-          "group": "SiegeEmergencyShieldGroup",
           "description": "<br><font color='#FF9900'>Makes a turret go invulnerable, then rain fire.</font><br><br>Makes the target turret invulnerable for 6 seconds. Two seconds before expiry, it unleashes a missile volley, dealing 650 true damage over the remaining time to all nearby enemies.<br><br>Cannot be used on the same turret more than once in 15 seconds",
           "colloq": "",
           "plaintext": "Make a turret go invulnerable while charging a powerful barrage",
@@ -16868,7 +16958,6 @@
         },
         "3640": {
           "name": "Flash Zone",
-          "group": "SiegeFlashZoneGroup",
           "description": "<br><font color='#FF9900'>Allows team to cast Flash repeatedly in a limited zone.</font><br><br>Creates a magic zone for your team for 5 seconds. While in this zone, you and your allies have your summoner spells replaced by an instant cast blink that moves you to any location in the zone (1 second cooldown)",
           "colloq": "",
           "plaintext": "Allows you and allies to repeatedly flash while in a zone",
@@ -16907,7 +16996,6 @@
         },
         "3641": {
           "name": "Vanguard Banner",
-          "group": "SiegePortableBarracksGroup",
           "description": "<br><font color='#FF9900'>Place a banner that buffs minions.</font><br><br>Place a Vanguard Banner at target location. After an 2 second delay, any nearby minions will be granted a buff, increasing their damage by 50%, and granting them 50 Armor and 100 Magic Resistance while within range.",
           "colloq": "",
           "plaintext": "Strengthens nearby minions",
@@ -16951,7 +17039,6 @@
         },
         "3642": {
           "name": "Siege Refund",
-          "group": "SiegeRefundGroup",
           "description": "Refunds all purchased Siege Weapons for their full price.",
           "colloq": ";",
           "plaintext": "Refunds all current Siege Weapons",
@@ -16989,7 +17076,6 @@
         },
         "3643": {
           "name": "Entropy Field",
-          "group": "SiegeTimefieldGroup",
           "description": "<br><font color='#FF9900'>Stun minions and slow champions in an area.</font><br><br>Places an Entropy Field at target location for 5 seconds.  Enemy minions and Siege Ballistas trapped in the field are unable to move or attack while in the field.  Enemy champions in the field have their Movement Speed reduced by 25%.",
           "colloq": "",
           "plaintext": "Places a field that stuns enemy minions and slows champions",
@@ -17029,7 +17115,6 @@
         },
         "3645": {
           "name": "Seer Stone (Trinket)",
-          "group": "RelicBase",
           "description": "<groupLimit>Limited to 1 Trinket.</groupLimit><br><br><active>Active:</active> Reveals a small area within <font color='#FFFFF'>1400</font> range for 3 seconds. Enemy champions will be revealed for 5 seconds (60 second cooldown)",
           "colloq": "blue;",
           "plaintext": "Briefly reveals a nearby targeted area",
@@ -17074,7 +17159,6 @@
         },
         "3647": {
           "name": "Shield Totem",
-          "group": "SiegeShieldGeneratorGroup",
           "description": "<br><font color='#FF9900'>Place a totem that shields nearby deployables.</font><br><br>Places a Shield Totem at target location. After a 2 second delay, the totem will activate, granting a 2 (+1 per additional Shield Totem) strength shield to all nearby deployables.",
           "colloq": "",
           "plaintext": "Grants bonus health to nearby Siege Weapons",
@@ -17345,8 +17429,7 @@
         },
         "3706": {
           "name": "Stalker's Blade",
-          "group": "JungleItems",
-          "description": "<groupLimit>Limited to 1 Jungle item</groupLimit><br><br><stats>+10% Life Steal vs. Monsters<br><mana>+180% Base Mana Regen while in Jungle</mana></stats><br><br><unique>UNIQUE Passive - Chilling Smite:</unique> Smite can be cast on enemy champions, dealing reduced true damage and stealing 20% Movement Speed for 2 seconds. <br><unique>UNIQUE Passive - Tooth / Nail:</unique> Basic attacks deal 20 bonus damage vs. monsters. Damaging a monster with a spell or attack steals 30 Health over 5 seconds. Killing monsters grants <font color='#99BBBB'><a href='SpecialJungleExperience'>special bonus experience</a></font>.",
+          "description": "<groupLimit>Limited to 1 Jungle item</groupLimit><br><br><stats>+10% Life Steal vs. Monsters<br><mana>+180% Base Mana Regen while in Jungle</mana></stats><br><br><unique>UNIQUE Passive - Chilling Smite:</unique> Smite can be cast on enemy champions, dealing reduced true damage and stealing 20% Movement Speed for 2 seconds. <br><unique>UNIQUE Passive - Tooth / Nail:</unique> Basic attacks deal 25 bonus damage vs. monsters. Damaging a monster with a spell or attack steals 30 Health over 5 seconds. Killing monsters grants <font color='#99BBBB'><a href='SpecialJungleExperience'>special bonus experience</a></font>.",
           "colloq": ";jungle;Jungle;jangle",
           "plaintext": "Lets your Smite slow Champions",
           "from": [
@@ -17393,7 +17476,7 @@
           "stats": {},
           "effect": {
             "Effect1Amount": "30",
-            "Effect2Amount": "20",
+            "Effect2Amount": "25",
             "Effect3Amount": "1.8",
             "Effect4Amount": "5",
             "Effect5Amount": "30",
@@ -17405,8 +17488,7 @@
         },
         "3711": {
           "name": "Tracker's Knife",
-          "group": "JungleItems",
-          "description": "<groupLimit>Limited to 1 Jungle item</groupLimit><br><br><stats>+10% Life Steal vs. Monsters<br><mana>+180% Base Mana Regen while in Jungle</mana></stats><br><br><unique>UNIQUE Passive - Tooth / Nail:</unique> Basic attacks deal 20 bonus damage vs. monsters. Damaging a monster with a spell or attack steals 30 Health over 5 seconds. Killing monsters grants <font color='#99BBBB'><a href='SpecialJungleExperience'>special bonus experience</a></font>.<br><active>UNIQUE Active - Warding:</active> Consumes a charge to place a <font color='#BBFFFF'>Stealth Ward</font> that reveals the surrounding area for 150 seconds. Holds up to 2 charges which refill upon visiting the shop. <br><br><rules>(A player may only have 3 <font color='#BBFFFF'>Stealth Wards</font> on the map at one time. Unique Passives with the same name don't stack.)</rules>",
+          "description": "<groupLimit>Limited to 1 Jungle item</groupLimit><br><br><stats>+10% Life Steal vs. Monsters<br><mana>+180% Base Mana Regen while in Jungle</mana></stats><br><br><unique>UNIQUE Passive - Tooth / Nail:</unique> Basic attacks deal 25 bonus damage vs. monsters. Damaging a monster with a spell or attack steals 30 Health over 5 seconds. Killing monsters grants <font color='#99BBBB'><a href='SpecialJungleExperience'>special bonus experience</a></font>.<br><active>UNIQUE Active - Warding:</active> Consumes a charge to place a <font color='#BBFFFF'>Stealth Ward</font> that reveals the surrounding area for 150 seconds. Holds up to 2 charges which refill upon visiting the shop. <br><br><rules>(A player may only have 3 <font color='#BBFFFF'>Stealth Wards</font> on the map at one time. Unique Passives with the same name don't stack.)</rules>",
           "colloq": ";jungle;Jungle",
           "plaintext": "Provides Stealth Wards over time",
           "from": [
@@ -17453,7 +17535,7 @@
           "stats": {},
           "effect": {
             "Effect1Amount": "30",
-            "Effect2Amount": "20",
+            "Effect2Amount": "25",
             "Effect3Amount": "1.8",
             "Effect4Amount": "5",
             "Effect5Amount": "30",
@@ -17465,8 +17547,7 @@
         },
         "3715": {
           "name": "Skirmisher's Sabre",
-          "group": "JungleItems",
-          "description": "<groupLimit>Limited to 1 Jungle item</groupLimit><br><br><stats>+10% Life Steal vs. Monsters<br><mana>+180% Base Mana Regen while in Jungle</mana></stats><br><br><passive>Passive - Challenging Smite:</passive> Smite can be cast on enemy champions, marking them for 4 seconds. While marked, basic attacks deal bonus true damage over 3 seconds, you have vision of them, and their damage to you is reduced by 20%.<br><unique>UNIQUE Passive - Tooth / Nail:</unique> Basic attacks deal 20 bonus damage vs. monsters. Damaging a monster with a spell or attack steals 30 Health over 5 seconds. Killing monsters grants <font color='#99BBBB'><a href='SpecialJungleExperience'>special bonus experience</a></font>.",
+          "description": "<groupLimit>Limited to 1 Jungle item</groupLimit><br><br><stats>+10% Life Steal vs. Monsters<br><mana>+180% Base Mana Regen while in Jungle</mana></stats><br><br><passive>Passive - Challenging Smite:</passive> Smite can be cast on enemy champions, marking them for 4 seconds. While marked, basic attacks deal bonus true damage over 3 seconds, you have vision of them, and their damage to you is reduced by 20%.<br><unique>UNIQUE Passive - Tooth / Nail:</unique> Basic attacks deal 25 bonus damage vs. monsters. Damaging a monster with a spell or attack steals 30 Health over 5 seconds. Killing monsters grants <font color='#99BBBB'><a href='SpecialJungleExperience'>special bonus experience</a></font>.",
           "colloq": ";jungle;Jungle",
           "plaintext": "Lets your Smite mark Champions, giving you combat power against them.",
           "from": [
@@ -17511,7 +17592,7 @@
           "stats": {},
           "effect": {
             "Effect1Amount": "30",
-            "Effect2Amount": "20",
+            "Effect2Amount": "25",
             "Effect3Amount": "1.8",
             "Effect4Amount": "5",
             "Effect5Amount": "30",
@@ -17752,9 +17833,10 @@
             "1006"
           ],
           "into": [
-            "3105",
             "3083",
             "3084",
+            "3107",
+            "3109",
             "3800"
           ],
           "image": {
@@ -17895,9 +17977,62 @@
           },
           "depth": 3
         },
+        "3814": {
+          "name": "Edge of Night",
+          "description": "<stats>+60 Attack Damage<br>+35 Magic Resist</stats><br><br><unique>UNIQUE Passive:</unique> +15 <a href='Lethality'>Lethality</a><br><unique>UNIQUE Passive:</unique> +20 Movement Speed out of Combat<br><unique>UNIQUE Active - Night's Veil:</unique> Channel for 1.5 second to grant a spell shield that blocks the next enemy ability. Lasts for 10 seconds (45 second cooldown).<br><br><rules>(Can move while channeling, but taking damage breaks the channel.)</rules>",
+          "colloq": ";lethality",
+          "plaintext": "Blocks an incoming enemy spell.",
+          "stacks": 0,
+          "from": [
+            "1037",
+            "3134",
+            "1033"
+          ],
+          "into": [],
+          "image": {
+            "full": "3814.png",
+            "sprite": "item2.png",
+            "group": "item",
+            "x": 336,
+            "y": 192,
+            "w": 48,
+            "h": 48
+          },
+          "gold": {
+            "base": 675,
+            "purchasable": true,
+            "total": 3100,
+            "sell": 2170
+          },
+          "tags": [
+            "ArmorPenetration",
+            "Damage",
+            "NonbootsMovement",
+            "SpellBlock"
+          ],
+          "maps": {
+            "1": false,
+            "8": true,
+            "10": true,
+            "11": true,
+            "12": true,
+            "14": false
+          },
+          "stats": {
+            "FlatPhysicalDamageMod": 60,
+            "FlatSpellBlockMod": 35
+          },
+          "effect": {
+            "Effect1Amount": "15",
+            "Effect2Amount": "0",
+            "Effect3Amount": "20",
+            "Effect4Amount": "45",
+            "Effect5Amount": "5"
+          },
+          "depth": 3
+        },
         "3901": {
           "name": "Fire at Will",
-          "group": "GangplankRUpgrade01",
           "description": "Requires 500 Silver Serpents.<br><br><unique>UNIQUE Passive:</unique> Cannon Barrage fires at an increasing rate over time (additional 6 waves over the duration).",
           "colloq": "",
           "plaintext": "Cannon Barrage gains extra waves",
@@ -17933,7 +18068,6 @@
         },
         "3902": {
           "name": "Death's Daughter",
-          "group": "GangplankRUpgrade02",
           "description": "Requires 500 Silver Serpents.<br><br><unique>UNIQUE Passive:</unique> Cannon Barrage additionally fires a mega-cannonball at center of the Barrage, dealing 300% true damage and slowing them by 60% for 1.5 seconds. ",
           "colloq": "",
           "plaintext": "Cannon Barrage fires a mega-cannonball",
@@ -17969,7 +18103,6 @@
         },
         "3903": {
           "name": "Raise Morale",
-          "group": "GangplankRUpgrade03",
           "description": "Requires 500 Silver Serpents.<br><br><unique>UNIQUE Passive:</unique> Allies in the Cannon Barrage gain 30% Movement Speed for 2 seconds.",
           "colloq": "",
           "plaintext": "Cannon Barrage hastes allies",
@@ -18285,21 +18418,21 @@
     },
     "headers": {
       "content-type": "application/json",
-      "content-length": "205473",
+      "content-length": "208092",
       "connection": "close",
       "accept-ranges": "bytes",
       "access-control-allow-origin": "*",
       "cache-control": "max-age=315360000, public",
-      "date": "Tue, 18 Oct 2016 03:00:06 GMT",
-      "etag": "\"289f51-322a1-53f07234b1f40\"",
+      "date": "Fri, 04 Nov 2016 03:00:07 GMT",
+      "etag": "\"30bf3f-32cdc-5406e22348200\"",
       "expires": "Thu, 31 Dec 2099 00:00:00 GMT",
-      "last-modified": "Mon, 17 Oct 2016 03:26:13 GMT",
+      "last-modified": "Thu, 03 Nov 2016 23:44:08 GMT",
       "server": "Apache/2.2.29 (Amazon)",
-      "via": "1.1 varnish, 1.1 e5740b731d03d61279af4365058ca2f2.cloudfront.net (CloudFront)",
-      "x-varnish": "2092555399",
-      "age": "1178208",
+      "via": "1.1 varnish, 1.1 4b9c0f334477218dc41b7165cd42cccd.cloudfront.net (CloudFront)",
+      "x-varnish": "2423686980",
+      "age": "819936",
       "x-cache": "Hit from cloudfront",
-      "x-amz-cf-id": "dn6IIYkwOcExkRhfu59k9r1m3mqn0Oa7HzonVScC245mNrTIFa1ITg=="
+      "x-amz-cf-id": "SHMEujDUkqWWua8Crg_3yvlU1TLIT827hszD8-2efgWKUBBkte_LNw=="
     }
   }
 ]

--- a/test/mocks/mocks/get__summoner_performance_should_require_champion_param_to_exist.json
+++ b/test/mocks/mocks/get__summoner_performance_should_require_champion_param_to_exist.json
@@ -6,8 +6,7 @@
     "body": "",
     "status": 200,
     "response": [
-      "1f8b0800000000000000",
-      "258b390a80301045eff2eb1493282ea96d04f10e4147089889c4a509dedd80ed5b32845d700936c3afb05d4364c8340ae202c362feb5c291e2e6771e972863090d299c770851384dfcf00e5b1594f8f1a78f32b8abdcba6eeb4a77a6d744f4be1f5be62a296d000000"
+      "1f8b0800000000000000258b390a80301045eff2eb1493282ea96d04f10e4147089889c4a509dedd80ed5b32845d700936c3afb05d4364c8340ae202c362feb5c291e2e6771e972863090d299c770851384dfcf00e5b1594f8f1a78f32b8abdcba6eeb4a77a6d744f4be1f5be62a296d000000"
     ],
     "headers": {
       "access-control-allow-headers": "Content-Type",
@@ -15,11 +14,11 @@
       "access-control-allow-origin": "*",
       "content-encoding": "gzip",
       "content-type": "application/json;charset=utf-8",
-      "date": "Mon, 31 Oct 2016 17:32:53 GMT",
+      "date": "Thu, 10 Nov 2016 19:34:46 GMT",
       "vary": "Accept-Encoding, User-Agent",
-      "x-newrelic-app-data": "PxQFWFFSDwQTVVdUBAgPUkYdFGQHBDcQUQxLA1tMXV1dORYzVBBGBxdCdhUSEVFRRRAEPhhQRw84HlpcDjpMB0UVZE1OCRoGb0pKFFwMXAwBRGtOBBoVXVEJBD4YGxVKVB8GH1JIU1IBVA9RAA0HHh5UFUMHVAIEV1MHUFJTWlFWU1lRFWw=",
-      "x-rate-limit-count": "325:10,13669:600",
-      "transfer-encoding": "chunked",
+      "x-newrelic-app-data": "PxQFWFFSDwQTVVdUBAgPUkYdFGQHBDcQUQxLA1tMXV1dORYzVBBGBxdCdhUSEVFRRRAEPhhQRw84HlpcDjpMB0UVZE1OCRoGb0pKFFwMXAwBRGtOBBoVXVEJBD4YGxVKVB8GH1JIU1IBWglQAAkNHh5UFUNSUVVUAlAAVV8BXVJUXFAAFR1RBwhCU24=",
+      "x-rate-limit-count": "260:10,15910:600",
+      "content-length": "115",
       "connection": "Close"
     }
   },
@@ -31,21 +30,21 @@
     "status": 200,
     "response": {
       "n": {
-        "item": "6.21.1",
-        "rune": "6.21.1",
-        "mastery": "6.21.1",
-        "summoner": "6.21.1",
-        "champion": "6.21.1",
-        "profileicon": "6.21.1",
-        "map": "6.21.1",
-        "language": "6.21.1"
+        "item": "6.22.1",
+        "rune": "6.22.1",
+        "mastery": "6.22.1",
+        "summoner": "6.22.1",
+        "champion": "6.22.1",
+        "profileicon": "6.22.1",
+        "map": "6.22.1",
+        "language": "6.22.1"
       },
-      "v": "6.21.1",
+      "v": "6.22.1",
       "l": "en_GB",
-      "cdn": "https://ddragon.leagueoflegends.com/cdn",
-      "dd": "6.21.1",
-      "lg": "6.21.1",
-      "css": "6.21.1",
+      "cdn": "http://ddragon.leagueoflegends.com/cdn",
+      "dd": "6.22.1",
+      "lg": "6.22.1",
+      "css": "6.22.1",
       "profileiconmax": 28,
       "store": null
     },
@@ -55,32 +54,32 @@
       "connection": "close",
       "accept-ranges": "bytes",
       "access-control-allow-origin": "*",
-      "age": "389",
+      "age": "383",
       "cache-control": "must-revalidate, no-cache, private",
-      "date": "Mon, 31 Oct 2016 17:32:53 GMT",
-      "etag": "\"89b376aa3d1ca56a0db73019ef158cc2\"",
+      "date": "Thu, 10 Nov 2016 19:34:46 GMT",
+      "etag": "\"b629bafa47432ff8c0555937d69dd18e\"",
       "server": "Apache/2.2.29 (Amazon)",
-      "via": "1.1 varnish, 1.1 3b0d50fb082748994f502e6e245c0a27.cloudfront.net (CloudFront)",
-      "x-content-digest": "en0bb0db99ba6eaaeb0ba4bb7c1d898bf646f54351",
+      "via": "1.1 varnish, 1.1 5492daf6fc6457427d8da282b92e1dee.cloudfront.net (CloudFront)",
+      "x-content-digest": "enc240ea78e07b1e8b664f1ad5ff5349862f5dab90",
       "x-powered-by": "PHP/5.3.29",
-      "x-varnish": "2361378554 2361275088",
+      "x-varnish": "2548804494 2548687645",
       "x-cache": "Miss from cloudfront",
-      "x-amz-cf-id": "yrSF6Igy7HcdorXvQ24h7QIZYIw4-UrUYrAflLJYNzmEgMM3P_Ibgw=="
+      "x-amz-cf-id": "FEUWp0SPsqVh4DMcNBW5SkPtldu9kH1gWHbuNHOd8HsyfvyEejBD6w=="
     }
   },
   {
     "scope": "https://ddragon.leagueoflegends.com:443",
     "method": "GET",
-    "path": "/cdn/6.21.1/data/en_US/champion.json",
+    "path": "/cdn/6.22.1/data/en_US/champion.json",
     "body": "",
     "status": 200,
     "response": {
       "type": "champion",
       "format": "standAloneComplex",
-      "version": "6.21.1",
+      "version": "6.22.1",
       "data": {
         "Aatrox": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Aatrox",
           "key": "266",
           "name": "Aatrox",
@@ -130,7 +129,7 @@
           }
         },
         "Ahri": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Ahri",
           "key": "103",
           "name": "Ahri",
@@ -180,7 +179,7 @@
           }
         },
         "Akali": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Akali",
           "key": "84",
           "name": "Akali",
@@ -229,7 +228,7 @@
           }
         },
         "Alistar": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Alistar",
           "key": "12",
           "name": "Alistar",
@@ -279,7 +278,7 @@
           }
         },
         "Amumu": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Amumu",
           "key": "32",
           "name": "Amumu",
@@ -329,7 +328,7 @@
           }
         },
         "Anivia": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Anivia",
           "key": "34",
           "name": "Anivia",
@@ -379,7 +378,7 @@
           }
         },
         "Annie": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Annie",
           "key": "1",
           "name": "Annie",
@@ -428,7 +427,7 @@
           }
         },
         "Ashe": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Ashe",
           "key": "22",
           "name": "Ashe",
@@ -478,7 +477,7 @@
           }
         },
         "AurelionSol": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "AurelionSol",
           "key": "136",
           "name": "Aurelion Sol",
@@ -528,7 +527,7 @@
           }
         },
         "Azir": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Azir",
           "key": "268",
           "name": "Azir",
@@ -578,7 +577,7 @@
           }
         },
         "Bard": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Bard",
           "key": "432",
           "name": "Bard",
@@ -628,7 +627,7 @@
           }
         },
         "Blitzcrank": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Blitzcrank",
           "key": "53",
           "name": "Blitzcrank",
@@ -678,7 +677,7 @@
           }
         },
         "Brand": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Brand",
           "key": "63",
           "name": "Brand",
@@ -727,7 +726,7 @@
           }
         },
         "Braum": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Braum",
           "key": "201",
           "name": "Braum",
@@ -777,7 +776,7 @@
           }
         },
         "Caitlyn": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Caitlyn",
           "key": "51",
           "name": "Caitlyn",
@@ -826,7 +825,7 @@
           }
         },
         "Cassiopeia": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Cassiopeia",
           "key": "69",
           "name": "Cassiopeia",
@@ -875,7 +874,7 @@
           }
         },
         "Chogath": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Chogath",
           "key": "31",
           "name": "Cho'Gath",
@@ -925,7 +924,7 @@
           }
         },
         "Corki": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Corki",
           "key": "42",
           "name": "Corki",
@@ -974,7 +973,7 @@
           }
         },
         "Darius": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Darius",
           "key": "122",
           "name": "Darius",
@@ -1024,7 +1023,7 @@
           }
         },
         "Diana": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Diana",
           "key": "131",
           "name": "Diana",
@@ -1074,7 +1073,7 @@
           }
         },
         "Draven": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Draven",
           "key": "119",
           "name": "Draven",
@@ -1123,7 +1122,7 @@
           }
         },
         "DrMundo": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "DrMundo",
           "key": "36",
           "name": "Dr. Mundo",
@@ -1173,7 +1172,7 @@
           }
         },
         "Ekko": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Ekko",
           "key": "245",
           "name": "Ekko",
@@ -1212,7 +1211,7 @@
             "attackrange": 125,
             "hpregen": 9,
             "hpregenperlevel": 0.9,
-            "mpregen": 6,
+            "mpregen": 7,
             "mpregenperlevel": 0.8,
             "crit": 0,
             "critperlevel": 0,
@@ -1223,7 +1222,7 @@
           }
         },
         "Elise": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Elise",
           "key": "60",
           "name": "Elise",
@@ -1273,7 +1272,7 @@
           }
         },
         "Evelynn": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Evelynn",
           "key": "28",
           "name": "Evelynn",
@@ -1323,7 +1322,7 @@
           }
         },
         "Ezreal": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Ezreal",
           "key": "81",
           "name": "Ezreal",
@@ -1373,7 +1372,7 @@
           }
         },
         "FiddleSticks": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "FiddleSticks",
           "key": "9",
           "name": "Fiddlesticks",
@@ -1423,7 +1422,7 @@
           }
         },
         "Fiora": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Fiora",
           "key": "114",
           "name": "Fiora",
@@ -1473,7 +1472,7 @@
           }
         },
         "Fizz": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Fizz",
           "key": "105",
           "name": "Fizz",
@@ -1523,7 +1522,7 @@
           }
         },
         "Galio": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Galio",
           "key": "3",
           "name": "Galio",
@@ -1573,7 +1572,7 @@
           }
         },
         "Gangplank": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Gangplank",
           "key": "41",
           "name": "Gangplank",
@@ -1622,7 +1621,7 @@
           }
         },
         "Garen": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Garen",
           "key": "86",
           "name": "Garen",
@@ -1672,7 +1671,7 @@
           }
         },
         "Gnar": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Gnar",
           "key": "150",
           "name": "Gnar",
@@ -1722,7 +1721,7 @@
           }
         },
         "Gragas": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Gragas",
           "key": "79",
           "name": "Gragas",
@@ -1772,7 +1771,7 @@
           }
         },
         "Graves": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Graves",
           "key": "104",
           "name": "Graves",
@@ -1821,7 +1820,7 @@
           }
         },
         "Hecarim": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Hecarim",
           "key": "120",
           "name": "Hecarim",
@@ -1871,7 +1870,7 @@
           }
         },
         "Heimerdinger": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Heimerdinger",
           "key": "74",
           "name": "Heimerdinger",
@@ -1921,7 +1920,7 @@
           }
         },
         "Illaoi": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Illaoi",
           "key": "420",
           "name": "Illaoi",
@@ -1971,7 +1970,7 @@
           }
         },
         "Irelia": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Irelia",
           "key": "39",
           "name": "Irelia",
@@ -2021,7 +2020,7 @@
           }
         },
         "Ivern": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Ivern",
           "key": "427",
           "name": "Ivern",
@@ -2071,7 +2070,7 @@
           }
         },
         "Janna": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Janna",
           "key": "40",
           "name": "Janna",
@@ -2121,7 +2120,7 @@
           }
         },
         "JarvanIV": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "JarvanIV",
           "key": "59",
           "name": "Jarvan IV",
@@ -2171,7 +2170,7 @@
           }
         },
         "Jax": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Jax",
           "key": "24",
           "name": "Jax",
@@ -2221,7 +2220,7 @@
           }
         },
         "Jayce": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Jayce",
           "key": "126",
           "name": "Jayce",
@@ -2271,7 +2270,7 @@
           }
         },
         "Jhin": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Jhin",
           "key": "202",
           "name": "Jhin",
@@ -2321,7 +2320,7 @@
           }
         },
         "Jinx": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Jinx",
           "key": "222",
           "name": "Jinx",
@@ -2370,7 +2369,7 @@
           }
         },
         "Kalista": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Kalista",
           "key": "429",
           "name": "Kalista",
@@ -2419,7 +2418,7 @@
           }
         },
         "Karma": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Karma",
           "key": "43",
           "name": "Karma",
@@ -2469,7 +2468,7 @@
           }
         },
         "Karthus": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Karthus",
           "key": "30",
           "name": "Karthus",
@@ -2518,7 +2517,7 @@
           }
         },
         "Kassadin": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Kassadin",
           "key": "38",
           "name": "Kassadin",
@@ -2568,7 +2567,7 @@
           }
         },
         "Katarina": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Katarina",
           "key": "55",
           "name": "Katarina",
@@ -2595,18 +2594,18 @@
           ],
           "partype": "None",
           "stats": {
-            "hp": 510,
-            "hpperlevel": 83,
+            "hp": 590,
+            "hpperlevel": 82,
             "mp": 0,
             "mpperlevel": 0,
-            "movespeed": 345,
-            "armor": 26.88,
+            "movespeed": 340,
+            "armor": 27.88,
             "armorperlevel": 3.5,
-            "spellblock": 32.1,
+            "spellblock": 34.1,
             "spellblockperlevel": 1.25,
             "attackrange": 125,
-            "hpregen": 4.5,
-            "hpregenperlevel": 0.55,
+            "hpregen": 7.5,
+            "hpregenperlevel": 0.7,
             "mpregen": 0,
             "mpregenperlevel": 0,
             "crit": 0,
@@ -2618,7 +2617,7 @@
           }
         },
         "Kayle": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Kayle",
           "key": "10",
           "name": "Kayle",
@@ -2668,7 +2667,7 @@
           }
         },
         "Kennen": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Kennen",
           "key": "85",
           "name": "Kennen",
@@ -2718,7 +2717,7 @@
           }
         },
         "Khazix": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Khazix",
           "key": "121",
           "name": "Kha'Zix",
@@ -2761,14 +2760,14 @@
             "mpregenperlevel": 0.5,
             "crit": 0,
             "critperlevel": 0,
-            "attackdamage": 55.208,
+            "attackdamage": 55.21,
             "attackdamageperlevel": 3.1,
             "attackspeedoffset": -0.065,
             "attackspeedperlevel": 2.7
           }
         },
         "Kindred": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Kindred",
           "key": "203",
           "name": "Kindred",
@@ -2817,7 +2816,7 @@
           }
         },
         "Kled": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Kled",
           "key": "240",
           "name": "Kled",
@@ -2867,7 +2866,7 @@
           }
         },
         "KogMaw": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "KogMaw",
           "key": "96",
           "name": "Kog'Maw",
@@ -2917,7 +2916,7 @@
           }
         },
         "Leblanc": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Leblanc",
           "key": "7",
           "name": "LeBlanc",
@@ -2945,17 +2944,17 @@
           "partype": "MP",
           "stats": {
             "hp": 516,
-            "hpperlevel": 75,
+            "hpperlevel": 80,
             "mp": 334,
             "mpperlevel": 50,
-            "movespeed": 335,
+            "movespeed": 340,
             "armor": 21.88,
             "armorperlevel": 3.5,
             "spellblock": 30,
             "spellblockperlevel": 0,
             "attackrange": 525,
-            "hpregen": 7.42,
-            "hpregenperlevel": 0.55,
+            "hpregen": 8.5,
+            "hpregenperlevel": 0.8,
             "mpregen": 6,
             "mpregenperlevel": 0.8,
             "crit": 0,
@@ -2967,7 +2966,7 @@
           }
         },
         "LeeSin": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "LeeSin",
           "key": "64",
           "name": "Lee Sin",
@@ -3017,7 +3016,7 @@
           }
         },
         "Leona": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Leona",
           "key": "89",
           "name": "Leona",
@@ -3067,7 +3066,7 @@
           }
         },
         "Lissandra": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Lissandra",
           "key": "127",
           "name": "Lissandra",
@@ -3116,7 +3115,7 @@
           }
         },
         "Lucian": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Lucian",
           "key": "236",
           "name": "Lucian",
@@ -3165,7 +3164,7 @@
           }
         },
         "Lulu": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Lulu",
           "key": "117",
           "name": "Lulu",
@@ -3215,7 +3214,7 @@
           }
         },
         "Lux": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Lux",
           "key": "99",
           "name": "Lux",
@@ -3265,7 +3264,7 @@
           }
         },
         "Malphite": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Malphite",
           "key": "54",
           "name": "Malphite",
@@ -3315,7 +3314,7 @@
           }
         },
         "Malzahar": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Malzahar",
           "key": "90",
           "name": "Malzahar",
@@ -3365,7 +3364,7 @@
           }
         },
         "Maokai": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Maokai",
           "key": "57",
           "name": "Maokai",
@@ -3415,7 +3414,7 @@
           }
         },
         "MasterYi": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "MasterYi",
           "key": "11",
           "name": "Master Yi",
@@ -3465,7 +3464,7 @@
           }
         },
         "MissFortune": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "MissFortune",
           "key": "21",
           "name": "Miss Fortune",
@@ -3514,7 +3513,7 @@
           }
         },
         "MonkeyKing": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "MonkeyKing",
           "key": "62",
           "name": "Wukong",
@@ -3564,7 +3563,7 @@
           }
         },
         "Mordekaiser": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Mordekaiser",
           "key": "82",
           "name": "Mordekaiser",
@@ -3613,7 +3612,7 @@
           }
         },
         "Morgana": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Morgana",
           "key": "25",
           "name": "Morgana",
@@ -3663,7 +3662,7 @@
           }
         },
         "Nami": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Nami",
           "key": "267",
           "name": "Nami",
@@ -3713,7 +3712,7 @@
           }
         },
         "Nasus": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Nasus",
           "key": "75",
           "name": "Nasus",
@@ -3763,7 +3762,7 @@
           }
         },
         "Nautilus": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Nautilus",
           "key": "111",
           "name": "Nautilus",
@@ -3813,7 +3812,7 @@
           }
         },
         "Nidalee": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Nidalee",
           "key": "76",
           "name": "Nidalee",
@@ -3863,7 +3862,7 @@
           }
         },
         "Nocturne": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Nocturne",
           "key": "56",
           "name": "Nocturne",
@@ -3913,7 +3912,7 @@
           }
         },
         "Nunu": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Nunu",
           "key": "20",
           "name": "Nunu",
@@ -3963,7 +3962,7 @@
           }
         },
         "Olaf": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Olaf",
           "key": "2",
           "name": "Olaf",
@@ -4013,7 +4012,7 @@
           }
         },
         "Orianna": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Orianna",
           "key": "61",
           "name": "Orianna",
@@ -4063,7 +4062,7 @@
           }
         },
         "Pantheon": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Pantheon",
           "key": "80",
           "name": "Pantheon",
@@ -4113,7 +4112,7 @@
           }
         },
         "Poppy": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Poppy",
           "key": "78",
           "name": "Poppy",
@@ -4163,7 +4162,7 @@
           }
         },
         "Quinn": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Quinn",
           "key": "133",
           "name": "Quinn",
@@ -4213,7 +4212,7 @@
           }
         },
         "Rammus": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Rammus",
           "key": "33",
           "name": "Rammus",
@@ -4263,7 +4262,7 @@
           }
         },
         "RekSai": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "RekSai",
           "key": "421",
           "name": "Rek'Sai",
@@ -4312,7 +4311,7 @@
           }
         },
         "Renekton": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Renekton",
           "key": "58",
           "name": "Renekton",
@@ -4362,7 +4361,7 @@
           }
         },
         "Rengar": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Rengar",
           "key": "107",
           "name": "Rengar",
@@ -4391,28 +4390,28 @@
           "stats": {
             "hp": 586.2,
             "hpperlevel": 90,
-            "mp": 5,
+            "mp": 4,
             "mpperlevel": 0,
             "movespeed": 345,
             "armor": 25.88,
-            "armorperlevel": 3.5,
+            "armorperlevel": 3,
             "spellblock": 32.1,
             "spellblockperlevel": 1.25,
             "attackrange": 125,
-            "hpregen": 4.27,
-            "hpregenperlevel": 0.4,
+            "hpregen": 7,
+            "hpregenperlevel": 0.5,
             "mpregen": 0,
             "mpregenperlevel": 0,
             "crit": 0,
             "critperlevel": 0,
-            "attackdamage": 60.04,
-            "attackdamageperlevel": 3,
-            "attackspeedoffset": -0.08,
-            "attackspeedperlevel": 2.85
+            "attackdamage": 60,
+            "attackdamageperlevel": 1,
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 3.5
           }
         },
         "Riven": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Riven",
           "key": "92",
           "name": "Riven",
@@ -4462,7 +4461,7 @@
           }
         },
         "Rumble": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Rumble",
           "key": "68",
           "name": "Rumble",
@@ -4512,7 +4511,7 @@
           }
         },
         "Ryze": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Ryze",
           "key": "13",
           "name": "Ryze",
@@ -4562,7 +4561,7 @@
           }
         },
         "Sejuani": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Sejuani",
           "key": "113",
           "name": "Sejuani",
@@ -4612,7 +4611,7 @@
           }
         },
         "Shaco": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Shaco",
           "key": "35",
           "name": "Shaco",
@@ -4661,7 +4660,7 @@
           }
         },
         "Shen": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Shen",
           "key": "98",
           "name": "Shen",
@@ -4711,7 +4710,7 @@
           }
         },
         "Shyvana": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Shyvana",
           "key": "102",
           "name": "Shyvana",
@@ -4761,7 +4760,7 @@
           }
         },
         "Singed": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Singed",
           "key": "27",
           "name": "Singed",
@@ -4811,7 +4810,7 @@
           }
         },
         "Sion": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Sion",
           "key": "14",
           "name": "Sion",
@@ -4861,7 +4860,7 @@
           }
         },
         "Sivir": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Sivir",
           "key": "15",
           "name": "Sivir",
@@ -4910,7 +4909,7 @@
           }
         },
         "Skarner": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Skarner",
           "key": "72",
           "name": "Skarner",
@@ -4960,7 +4959,7 @@
           }
         },
         "Sona": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Sona",
           "key": "37",
           "name": "Sona",
@@ -5010,7 +5009,7 @@
           }
         },
         "Soraka": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Soraka",
           "key": "16",
           "name": "Soraka",
@@ -5060,7 +5059,7 @@
           }
         },
         "Swain": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Swain",
           "key": "50",
           "name": "Swain",
@@ -5110,7 +5109,7 @@
           }
         },
         "Syndra": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Syndra",
           "key": "134",
           "name": "Syndra",
@@ -5160,7 +5159,7 @@
           }
         },
         "TahmKench": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "TahmKench",
           "key": "223",
           "name": "Tahm Kench",
@@ -5210,7 +5209,7 @@
           }
         },
         "Taliyah": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Taliyah",
           "key": "163",
           "name": "Taliyah",
@@ -5260,7 +5259,7 @@
           }
         },
         "Talon": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Talon",
           "key": "91",
           "name": "Talon",
@@ -5287,11 +5286,11 @@
           ],
           "partype": "MP",
           "stats": {
-            "hp": 582.8,
-            "hpperlevel": 85,
+            "hp": 583,
+            "hpperlevel": 90,
             "mp": 377.2,
             "mpperlevel": 37,
-            "movespeed": 350,
+            "movespeed": 335,
             "armor": 26.88,
             "armorperlevel": 3.5,
             "spellblock": 32.1,
@@ -5303,14 +5302,14 @@
             "mpregenperlevel": 0.5,
             "crit": 0,
             "critperlevel": 0,
-            "attackdamage": 55.208,
+            "attackdamage": 60,
             "attackdamageperlevel": 3.1,
-            "attackspeedoffset": -0.065,
-            "attackspeedperlevel": 2.7
+            "attackspeedoffset": 0,
+            "attackspeedperlevel": 2.9
           }
         },
         "Taric": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Taric",
           "key": "44",
           "name": "Taric",
@@ -5360,7 +5359,7 @@
           }
         },
         "Teemo": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Teemo",
           "key": "17",
           "name": "Teemo",
@@ -5410,7 +5409,7 @@
           }
         },
         "Thresh": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Thresh",
           "key": "412",
           "name": "Thresh",
@@ -5460,7 +5459,7 @@
           }
         },
         "Tristana": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Tristana",
           "key": "18",
           "name": "Tristana",
@@ -5510,7 +5509,7 @@
           }
         },
         "Trundle": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Trundle",
           "key": "48",
           "name": "Trundle",
@@ -5560,7 +5559,7 @@
           }
         },
         "Tryndamere": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Tryndamere",
           "key": "23",
           "name": "Tryndamere",
@@ -5610,7 +5609,7 @@
           }
         },
         "TwistedFate": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "TwistedFate",
           "key": "4",
           "name": "Twisted Fate",
@@ -5659,7 +5658,7 @@
           }
         },
         "Twitch": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Twitch",
           "key": "29",
           "name": "Twitch",
@@ -5709,7 +5708,7 @@
           }
         },
         "Udyr": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Udyr",
           "key": "77",
           "name": "Udyr",
@@ -5759,7 +5758,7 @@
           }
         },
         "Urgot": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Urgot",
           "key": "6",
           "name": "Urgot",
@@ -5809,7 +5808,7 @@
           }
         },
         "Varus": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Varus",
           "key": "110",
           "name": "Varus",
@@ -5859,7 +5858,7 @@
           }
         },
         "Vayne": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Vayne",
           "key": "67",
           "name": "Vayne",
@@ -5909,7 +5908,7 @@
           }
         },
         "Veigar": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Veigar",
           "key": "45",
           "name": "Veigar",
@@ -5958,7 +5957,7 @@
           }
         },
         "Velkoz": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Velkoz",
           "key": "161",
           "name": "Vel'Koz",
@@ -6007,7 +6006,7 @@
           }
         },
         "Vi": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Vi",
           "key": "254",
           "name": "Vi",
@@ -6057,7 +6056,7 @@
           }
         },
         "Viktor": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Viktor",
           "key": "112",
           "name": "Viktor",
@@ -6106,7 +6105,7 @@
           }
         },
         "Vladimir": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Vladimir",
           "key": "8",
           "name": "Vladimir",
@@ -6156,7 +6155,7 @@
           }
         },
         "Volibear": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Volibear",
           "key": "106",
           "name": "Volibear",
@@ -6206,7 +6205,7 @@
           }
         },
         "Warwick": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Warwick",
           "key": "19",
           "name": "Warwick",
@@ -6256,7 +6255,7 @@
           }
         },
         "Xerath": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Xerath",
           "key": "101",
           "name": "Xerath",
@@ -6306,7 +6305,7 @@
           }
         },
         "XinZhao": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "XinZhao",
           "key": "5",
           "name": "Xin Zhao",
@@ -6356,7 +6355,7 @@
           }
         },
         "Yasuo": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Yasuo",
           "key": "157",
           "name": "Yasuo",
@@ -6406,7 +6405,7 @@
           }
         },
         "Yorick": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Yorick",
           "key": "83",
           "name": "Yorick",
@@ -6456,7 +6455,7 @@
           }
         },
         "Zac": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Zac",
           "key": "154",
           "name": "Zac",
@@ -6506,7 +6505,7 @@
           }
         },
         "Zed": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Zed",
           "key": "238",
           "name": "Zed",
@@ -6556,7 +6555,7 @@
           }
         },
         "Ziggs": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Ziggs",
           "key": "115",
           "name": "Ziggs",
@@ -6605,7 +6604,7 @@
           }
         },
         "Zilean": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Zilean",
           "key": "26",
           "name": "Zilean",
@@ -6655,7 +6654,7 @@
           }
         },
         "Zyra": {
-          "version": "6.21.1",
+          "version": "6.22.1",
           "id": "Zyra",
           "key": "143",
           "name": "Zyra",
@@ -6708,32 +6707,32 @@
     },
     "headers": {
       "content-type": "application/json",
-      "content-length": "126739",
+      "content-length": "126725",
       "connection": "close",
       "accept-ranges": "bytes",
       "access-control-allow-origin": "*",
       "cache-control": "max-age=315360000, public",
-      "date": "Tue, 18 Oct 2016 03:00:05 GMT",
-      "etag": "\"289f4f-1ef13-53f07234b1f40\"",
+      "date": "Fri, 04 Nov 2016 03:00:06 GMT",
+      "etag": "\"30bf3d-1ef05-5406e22348200\"",
       "expires": "Thu, 31 Dec 2099 00:00:00 GMT",
-      "last-modified": "Mon, 17 Oct 2016 03:26:13 GMT",
+      "last-modified": "Thu, 03 Nov 2016 23:44:08 GMT",
       "server": "Apache/2.2.29 (Amazon)",
-      "via": "1.1 varnish, 1.1 e66a15cf6c7b01b2d613f4b2fc6c4f25.cloudfront.net (CloudFront)",
-      "x-varnish": "2092555336",
-      "age": "1175568",
+      "via": "1.1 varnish, 1.1 60db7b3e46bcf3e1268d126e7c2cf791.cloudfront.net (CloudFront)",
+      "x-varnish": "2423686877",
+      "age": "578080",
       "x-cache": "Hit from cloudfront",
-      "x-amz-cf-id": "Lq4mcgzRfC7GYE-G4WAB1tNrZNzGfT4BHIX2gnBSbqWbEyyX3iNL7w=="
+      "x-amz-cf-id": "-brmDr_BH4SLCz_LK8_VyFZHASE9dMxmUfFEde-tLzIW9Ajo5O91CQ=="
     }
   },
   {
     "scope": "https://ddragon.leagueoflegends.com:443",
     "method": "GET",
-    "path": "/cdn/6.21.1/data/en_US/item.json",
+    "path": "/cdn/6.22.1/data/en_US/item.json",
     "body": "",
     "status": 200,
     "response": {
       "type": "item",
-      "version": "6.21.1",
+      "version": "6.22.1",
       "basic": {
         "name": "",
         "rune": {
@@ -6839,7 +6838,6 @@
       "data": {
         "1001": {
           "name": "Boots of Speed",
-          "group": "BootsNormal",
           "description": "<groupLimit>Limited to 1.</groupLimit><br><br><unique>UNIQUE Passive - Enhanced Movement:</unique> +25 Movement Speed",
           "colloq": ";",
           "plaintext": "Slightly increases Movement Speed",
@@ -7150,8 +7148,8 @@
             "3052",
             "3044",
             "3067",
-            "3801",
             "3211",
+            "3801",
             "3136",
             "3748"
           ],
@@ -7197,7 +7195,9 @@
             "3024",
             "3082",
             "3075",
-            "2053"
+            "2053",
+            "3105",
+            "3109"
           ],
           "image": {
             "full": "1029.png",
@@ -7287,7 +7287,9 @@
             "3028",
             "3140",
             "3155",
-            "3105"
+            "3105",
+            "3190",
+            "3814"
           ],
           "image": {
             "full": "1033.png",
@@ -7337,7 +7339,8 @@
             "3122",
             "3134",
             "3144",
-            "3155"
+            "3155",
+            "3252"
           ],
           "image": {
             "full": "1036.png",
@@ -7384,7 +7387,8 @@
             "3124",
             "3139",
             "3181",
-            "3812"
+            "3812",
+            "3814"
           ],
           "image": {
             "full": "1037.png",
@@ -7509,7 +7513,7 @@
         },
         "1041": {
           "name": "Hunter's Machete",
-          "description": "<stats>+8% Life Steal vs. Monsters</stats><br><br><unique>UNIQUE Passive - Nail:</unique> Basic attacks deal 20 bonus damage on hit vs. Monsters. Killing monsters grants <font color='#99BBBB'><a href='SpecialJungleExperience'>special bonus experience</a></font>.",
+          "description": "<stats>+10% Life Steal vs. Monsters</stats><br><br><unique>UNIQUE Passive - Nail:</unique> Basic attacks deal 25 bonus damage on hit vs. Monsters. Killing monsters grants <font color='#99BBBB'><a href='SpecialJungleExperience'>special bonus experience</a></font>.",
           "colloq": ";jungle;Jungle",
           "plaintext": "Provides damage and life steal versus Monsters",
           "into": [
@@ -7548,8 +7552,8 @@
           "stats": {},
           "effect": {
             "Effect1Amount": "12",
-            "Effect2Amount": "20",
-            "Effect3Amount": "0.08",
+            "Effect2Amount": "25",
+            "Effect3Amount": "0.1",
             "Effect4Amount": "2",
             "Effect5Amount": "0",
             "Effect6Amount": "0.1",
@@ -7800,7 +7804,6 @@
         },
         "1054": {
           "name": "Doran's Shield",
-          "group": "DoransItems",
           "description": "<stats>+80 Health</stats><br><br><passive>Passive: </passive>Restores 6 Health every 5 seconds.<br><unique>UNIQUE Passive:</unique> Blocks 8 damage from single target attacks and spells from champions.",
           "colloq": ";dshield",
           "plaintext": "Good defensive starting item",
@@ -7830,7 +7833,7 @@
             "8": true,
             "10": true,
             "11": true,
-            "12": false,
+            "12": true,
             "14": false
           },
           "stats": {
@@ -7843,7 +7846,6 @@
         },
         "1055": {
           "name": "Doran's Blade",
-          "group": "DoransItems",
           "description": "<stats>+8 Attack Damage<br>+80 Health<br>+3% Life Steal</stats>",
           "colloq": ";dblade",
           "plaintext": "Good starting item for attackers",
@@ -7874,7 +7876,7 @@
             "8": true,
             "10": true,
             "11": true,
-            "12": false,
+            "12": true,
             "14": false
           },
           "stats": {
@@ -7888,7 +7890,6 @@
         },
         "1056": {
           "name": "Doran's Ring",
-          "group": "DoransItems",
           "description": "<stats>+60 Health<br>+15 Ability Power<br><mana>+50% Base Mana Regen </mana></stats><br><br><mana><passive>Passive:</passive> Restores 4 Mana upon killing a unit.</mana>",
           "colloq": ";dring",
           "plaintext": "Good starting item for casters",
@@ -7919,7 +7920,7 @@
             "8": true,
             "10": true,
             "11": true,
-            "12": false,
+            "12": true,
             "14": false
           },
           "stats": {
@@ -8116,7 +8117,6 @@
         },
         "1400": {
           "name": "Enchantment: Warrior",
-          "group": "JungleItems",
           "description": "<stats>+60 Attack Damage<br>+10% Cooldown Reduction</stats>",
           "colloq": ";",
           "plaintext": "Grants Attack Damage and Cooldown Reduction",
@@ -8155,7 +8155,7 @@
           },
           "effect": {
             "Effect1Amount": "30",
-            "Effect2Amount": "20",
+            "Effect2Amount": "25",
             "Effect3Amount": "1.8",
             "Effect4Amount": "5",
             "Effect5Amount": "30",
@@ -8167,7 +8167,6 @@
         },
         "1401": {
           "name": "Enchantment: Cinderhulk",
-          "group": "JungleItems",
           "description": "<stats>+400 Health<br>+15% Bonus Health</stats><br><br><unique>UNIQUE Passive - Immolate:</unique> Deals 7 (+2 per champion level) magic damage a second to nearby enemies while in combat. Deals 100% bonus damage to monsters. ",
           "colloq": ";",
           "plaintext": "Grants Health and Immolate Aura",
@@ -8206,7 +8205,7 @@
           },
           "effect": {
             "Effect1Amount": "30",
-            "Effect2Amount": "20",
+            "Effect2Amount": "25",
             "Effect3Amount": "1.8",
             "Effect4Amount": "5",
             "Effect5Amount": "30",
@@ -8218,7 +8217,6 @@
         },
         "1402": {
           "name": "Enchantment: Runic Echoes",
-          "group": "JungleItems",
           "description": "<stats>+60 Ability Power<br>+7% Movement Speed</stats><br><br><unique>UNIQUE Passive - Echo:</unique> Gain charges upon moving or casting. At 100 charges, the next damaging spell hit expends all charges to deal 60 (+10% of Ability Power) bonus magic damage to up to 4 targets on hit.<br><br>This effect deals 250% damage to Large Monsters. Hitting a Large Monster with this effect will restore 18% of your missing Mana.",
           "colloq": ";",
           "plaintext": "Grants Ability Power and periodically empowers your Spells",
@@ -8259,7 +8257,7 @@
           },
           "effect": {
             "Effect1Amount": "30",
-            "Effect2Amount": "20",
+            "Effect2Amount": "25",
             "Effect3Amount": "1.8",
             "Effect4Amount": "5",
             "Effect5Amount": "30",
@@ -8271,7 +8269,6 @@
         },
         "1408": {
           "name": "Enchantment: Warrior",
-          "group": "JungleItems",
           "description": "<stats>+60 Attack Damage<br>+10% Cooldown Reduction</stats>",
           "colloq": ";",
           "plaintext": "Grants Attack Damage and Cooldown Reduction",
@@ -8310,7 +8307,7 @@
           },
           "effect": {
             "Effect1Amount": "30",
-            "Effect2Amount": "20",
+            "Effect2Amount": "25",
             "Effect3Amount": "1.8",
             "Effect4Amount": "5",
             "Effect5Amount": "30",
@@ -8322,7 +8319,6 @@
         },
         "1409": {
           "name": "Enchantment: Cinderhulk",
-          "group": "JungleItems",
           "description": "<stats>+400 Health<br>+15% Bonus Health</stats><br><br><unique>UNIQUE Passive - Immolate:</unique> Deals 7 (+2 per champion level) magic damage a second to nearby enemies while in combat. Deals 100% bonus damage to monsters. ",
           "colloq": ";",
           "plaintext": "Grants Health and Immolate Aura",
@@ -8361,7 +8357,7 @@
           },
           "effect": {
             "Effect1Amount": "30",
-            "Effect2Amount": "20",
+            "Effect2Amount": "25",
             "Effect3Amount": "1.8",
             "Effect4Amount": "5",
             "Effect5Amount": "30",
@@ -8373,7 +8369,6 @@
         },
         "1410": {
           "name": "Enchantment: Runic Echoes",
-          "group": "JungleItems",
           "description": "<stats>+60 Ability Power<br>+7% Movement Speed</stats><br><br><unique>UNIQUE Passive - Echo:</unique> Gain charges upon moving or casting. At 100 charges, the next damaging spell hit expends all charges to deal 60 (+10% of Ability Power) bonus magic damage to up to 4 targets on hit.<br><br>This effect deals 250% damage to Large Monsters. Hitting a Large Monster with this effect will restore 18% of your missing Mana.",
           "colloq": ";",
           "plaintext": "Grants Ability Power and periodically empowers your Spells",
@@ -8414,7 +8409,7 @@
           },
           "effect": {
             "Effect1Amount": "30",
-            "Effect2Amount": "20",
+            "Effect2Amount": "25",
             "Effect3Amount": "1.8",
             "Effect4Amount": "5",
             "Effect5Amount": "30",
@@ -8426,7 +8421,6 @@
         },
         "1412": {
           "name": "Enchantment: Warrior",
-          "group": "JungleItems",
           "description": "<stats>+60 Attack Damage<br>+10% Cooldown Reduction</stats>",
           "colloq": ";",
           "plaintext": "Grants Attack Damage and Cooldown Reduction",
@@ -8465,7 +8459,7 @@
           },
           "effect": {
             "Effect1Amount": "30",
-            "Effect2Amount": "20",
+            "Effect2Amount": "25",
             "Effect3Amount": "1.8",
             "Effect4Amount": "5",
             "Effect5Amount": "30",
@@ -8477,7 +8471,6 @@
         },
         "1413": {
           "name": "Enchantment: Cinderhulk",
-          "group": "JungleItems",
           "description": "<stats>+400 Health<br>+15% Bonus Health</stats><br><br><unique>UNIQUE Passive - Immolate:</unique> Deals 7 (+2 per champion level) magic damage a second to nearby enemies while in combat. Deals 100% bonus damage to monsters. ",
           "colloq": ";",
           "plaintext": "Grants Health and Immolate Aura",
@@ -8516,7 +8509,7 @@
           },
           "effect": {
             "Effect1Amount": "30",
-            "Effect2Amount": "20",
+            "Effect2Amount": "25",
             "Effect3Amount": "1.8",
             "Effect4Amount": "5",
             "Effect5Amount": "30",
@@ -8528,7 +8521,6 @@
         },
         "1414": {
           "name": "Enchantment: Runic Echoes",
-          "group": "JungleItems",
           "description": "<stats>+60 Ability Power<br>+7% Movement Speed</stats><br><br><unique>UNIQUE Passive - Echo:</unique> Gain charges upon moving or casting. At 100 charges, the next damaging spell hit expends all charges to deal 60 (+10% of Ability Power) bonus magic damage to up to 4 targets on hit.<br><br>This effect deals 250% damage to Large Monsters. Hitting a Large Monster with this effect will restore 18% of your missing Mana.",
           "colloq": ";",
           "plaintext": "Grants Ability Power and periodically empowers your Spells",
@@ -8569,7 +8561,7 @@
           },
           "effect": {
             "Effect1Amount": "30",
-            "Effect2Amount": "20",
+            "Effect2Amount": "25",
             "Effect3Amount": "1.8",
             "Effect4Amount": "5",
             "Effect5Amount": "30",
@@ -8581,7 +8573,6 @@
         },
         "1416": {
           "name": "Enchantment: Bloodrazor",
-          "group": "JungleItems",
           "description": "<stats>+50% Attack Speed</stats><br><br><unique>UNIQUE Passive:</unique> Basic attacks deal 4% of the target's maximum Health in bonus physical damage (max 75 vs. monsters and minions) on hit.",
           "colloq": ";",
           "plaintext": "Increases Attack Speed and deals damage based on the target's Health",
@@ -8620,7 +8611,7 @@
           },
           "effect": {
             "Effect1Amount": "30",
-            "Effect2Amount": "20",
+            "Effect2Amount": "25",
             "Effect3Amount": "1.8",
             "Effect4Amount": "5",
             "Effect5Amount": "30",
@@ -8632,7 +8623,6 @@
         },
         "1418": {
           "name": "Enchantment: Bloodrazor",
-          "group": "JungleItems",
           "description": "<stats>+50% Attack Speed</stats><br><br><unique>UNIQUE Passive:</unique> Basic attacks deal 4% of the target's maximum Health in bonus physical damage (max 75 vs. monsters and minions) on hit.",
           "colloq": ";",
           "plaintext": "Increases Attack Speed and deals damage based on the target's Health",
@@ -8671,7 +8661,7 @@
           },
           "effect": {
             "Effect1Amount": "30",
-            "Effect2Amount": "20",
+            "Effect2Amount": "25",
             "Effect3Amount": "1.8",
             "Effect4Amount": "5",
             "Effect5Amount": "30",
@@ -8683,7 +8673,6 @@
         },
         "1419": {
           "name": "Enchantment: Bloodrazor",
-          "group": "JungleItems",
           "description": "<stats>+50% Attack Speed</stats><br><br><unique>UNIQUE Passive:</unique> Basic attacks deal 4% of the target's maximum Health in bonus physical damage (max 75 vs. monsters and minions) on hit.",
           "colloq": ";",
           "plaintext": "Increases Attack Speed and deals damage based on the target's Health",
@@ -8722,7 +8711,7 @@
           },
           "effect": {
             "Effect1Amount": "30",
-            "Effect2Amount": "20",
+            "Effect2Amount": "25",
             "Effect3Amount": "1.8",
             "Effect4Amount": "5",
             "Effect5Amount": "30",
@@ -8734,7 +8723,6 @@
         },
         "2003": {
           "name": "Health Potion",
-          "group": "HealthPotion",
           "description": "<groupLimit>Limited to 5 at one time. Limited to 1 type of Healing Potion.</groupLimit><br><br><consumable>Click to Consume:</consumable> Restores 150 Health over 15 seconds.",
           "colloq": ";",
           "plaintext": "Consume to restore Health over time",
@@ -8811,7 +8799,6 @@
         },
         "2010": {
           "name": "Total Biscuit of Rejuvenation",
-          "group": "HealthPotion",
           "description": "<consumable>Click to Consume:</consumable> Restores 15 Health and 15 Mana immediately and then 150 Health over 15 seconds.",
           "colloq": ";",
           "plaintext": "",
@@ -8900,7 +8887,6 @@
         },
         "2031": {
           "name": "Refillable Potion",
-          "group": "FlaskGroup",
           "description": "<groupLimit>Limited to 1 type of Healing Potion.</groupLimit><br><br><active>UNIQUE Active:</active> Consumes a charge to restore 125 Health over 12 seconds. Holds up to 2 charges and refills upon visiting the shop.",
           "colloq": ";",
           "plaintext": "Restores Health over time. Refills at shop.",
@@ -8948,7 +8934,6 @@
         },
         "2032": {
           "name": "Hunter's Potion",
-          "group": "FlaskGroup",
           "description": "<groupLimit>Limited to 1 type of Healing Potion.</groupLimit><br><br><active>UNIQUE Active:</active> Consumes a charge to restore 60 Health and 35 Mana over 8 seconds. Holds up to 5 charges and refills upon visiting the shop.<br><br>Killing a Large Monster grants 1 charge.<br><br><rules>(Killing a Large Monster at full charges will automatically consume the newest charge.)</rules>",
           "colloq": ";",
           "plaintext": "Restores Health and Mana over time - Refills at shop and has increased capacity",
@@ -8997,7 +8982,6 @@
         },
         "2033": {
           "name": "Corrupting Potion",
-          "group": "FlaskGroup",
           "description": "<groupLimit>Limited to 1 type of Healing Potion.</groupLimit><br><br><active>UNIQUE Active:</active> Consumes a charge to restore 125 Health and 75 Mana over 12 seconds and grants <font color='#FF8811'><u>Touch of Corruption</u></font> during that time. Holds up to 3 charges that refills upon visiting the shop.<br><br><font color='#FF8811'><u>Touch of Corruption:</u></font> Damaging spells and attacks burn enemy champions for <levelScale>15 - 30</levelScale> magic damage over 3 seconds. (Half Damage for Area of Effect or Damage over Time spells. Damage increases with champion level.)<br><br><rules>(Corrupting Potion can be used even at full Health and Mana.)</rules>",
           "colloq": ";",
           "plaintext": "Restores Health and Mana over time and boosts combat power - Refills at Shop",
@@ -9047,50 +9031,6 @@
             "Effect8Amount": "3"
           },
           "depth": 2
-        },
-        "2043": {
-          "name": "Vision Ward",
-          "group": "PinkWards",
-          "description": "<groupLimit>Can only carry 2 Vision Wards in inventory.</groupLimit><br><br><consumable>Click to Consume:</consumable> Places a visible ward that reveals the surrounding area and invisible units in the area until killed. Limit 1 <font color='#BBFFFF'>Vision Ward</font> on the map per player.<br><br><rules>(Revealing a ward in this manner grants a portion of the gold reward when that unit is killed.)</rules>",
-          "colloq": "pink;",
-          "plaintext": "Use to provide vision and stealth detection in an area until destroyed",
-          "consumed": true,
-          "stacks": 2,
-          "into": [],
-          "image": {
-            "full": "2043.png",
-            "sprite": "item0.png",
-            "group": "item",
-            "x": 48,
-            "y": 240,
-            "w": 48,
-            "h": 48
-          },
-          "gold": {
-            "base": 75,
-            "purchasable": true,
-            "total": 75,
-            "sell": 30
-          },
-          "tags": [
-            "Consumable",
-            "Lane",
-            "Stealth",
-            "Vision"
-          ],
-          "maps": {
-            "1": false,
-            "8": false,
-            "10": false,
-            "11": true,
-            "12": false,
-            "14": false
-          },
-          "stats": {},
-          "effect": {
-            "Effect1Amount": "1",
-            "Effect2Amount": "2"
-          }
         },
         "2045": {
           "name": "Ruby Sightstone",
@@ -9266,7 +9206,6 @@
         },
         "2051": {
           "name": "Guardian's Horn",
-          "group": "GuardianItems",
           "description": "<stats>+150 Health</stats><br><br><passive>Passive: </passive>Restores 20 Health every 5 seconds.<br><unique>UNIQUE Passive:</unique> Blocks 12 damage from attacks and spells from champions (25% effectiveness vs. damage over time abilities).<br><br><groupLimit>Limited to 1 Guardian's Item.</groupLimit>",
           "colloq": "Golden Arm of Kobe;Golden Bicep of Kobe;Horn; Horn of the ManWolf; ManWolf",
           "plaintext": "Good starting item for tanks",
@@ -9310,7 +9249,6 @@
         },
         "2052": {
           "name": "Poro-Snax",
-          "group": "PoroSnax",
           "description": "This savory blend of free-range, grass-fed Avarosan game hens and organic, non-ZMO Freljordian herbs contains the essential nutrients necessary to keep your Poro purring with pleasure.<br><br><i>All proceeds will be donated towards fighting Noxian animal cruelty.</i>",
           "colloq": ";",
           "plaintext": "",
@@ -9397,7 +9335,6 @@
         },
         "2054": {
           "name": "Diet Poro-Snax",
-          "group": "RelicBase",
           "description": "All the flavor of regular Poro-Snax, without the calories! Keeps your Poro happy AND healthy.<br><br><consumable>Click to Consume:</consumable> Gives your Poros a delicious healthy treat.",
           "colloq": ";",
           "plaintext": "",
@@ -9430,9 +9367,51 @@
           },
           "stats": {}
         },
+        "2055": {
+          "name": "Control Ward",
+          "description": "<groupLimit>Can only carry 3 Control Wards in inventory.</groupLimit><br><br><consumable>Click to Consume:</consumable> Places a ward that reveals the surrounding area. This device will disable and reveal nearby <a hred='wards'>wards</a> and hidden <a hred='traps'>traps</a>. Control Wards do not disable other Control Wards. Camouflaged units will also be revealed. <br><br>Limit 1 <font color='#BBFFFF'>Control Ward</font> on the map per player.",
+          "colloq": "orange;",
+          "plaintext": "Used to disable wards and invisible traps in an area.",
+          "consumed": true,
+          "stacks": 3,
+          "into": [],
+          "image": {
+            "full": "2055.png",
+            "sprite": "item2.png",
+            "group": "item",
+            "x": 144,
+            "y": 192,
+            "w": 48,
+            "h": 48
+          },
+          "gold": {
+            "base": 75,
+            "purchasable": true,
+            "total": 75,
+            "sell": 30
+          },
+          "tags": [
+            "Consumable",
+            "Lane",
+            "Stealth",
+            "Vision"
+          ],
+          "maps": {
+            "1": false,
+            "8": false,
+            "10": false,
+            "11": true,
+            "12": false,
+            "14": false
+          },
+          "stats": {},
+          "effect": {
+            "Effect1Amount": "1",
+            "Effect2Amount": "3"
+          }
+        },
         "2138": {
           "name": "Elixir of Iron",
-          "group": "Flasks",
           "description": "<stats><levelLimit>Level 9 required to purchase.</levelLimit></stats><br><br><consumable>Click to Consume:</consumable> Grants +300 Health, 25% Tenacity, increased champion size, and <font color='#FF8811'><u>Path of Iron</u></font> for 3 minutes.<br><br><font color='#FF8811'><u>Path of Iron:</u></font> Moving leaves a path behind that boosts allied champion's Movement Speed by 15%.<br><br><rules>(Only one Elixir effect may be active at a time.)</rules>",
           "colloq": ";white",
           "plaintext": "Temporarily increases defenses. Leaves a trail for allies to follow.",
@@ -9482,7 +9461,6 @@
         },
         "2139": {
           "name": "Elixir of Sorcery",
-          "group": "Flasks",
           "description": "<stats><levelLimit>Level 9 required to purchase.</levelLimit></stats><br><br><consumable>Click to Consume:</consumable> Grants +50 Ability Power, 15 bonus Mana Regen per 5 seconds and <font color='#FF8811'><u>Sorcery</u></font> for 3 minutes. <br><br><font color='#FF8811'><u>Sorcery:</u></font> Damaging a champion or turret deals 25 bonus True Damage. This effect has a 5 second cooldown versus champions but no cooldown versus turrets.<br><br><rules>(Only one Elixir effect may be active at a time.)</rules><br>",
           "colloq": ";blue",
           "plaintext": "Temporarily grants Ability Power and Bonus Damage to champions and turrets.",
@@ -9531,7 +9509,6 @@
         },
         "2140": {
           "name": "Elixir of Wrath",
-          "group": "Flasks",
           "description": "<stats><levelLimit>Level 9 required to purchase.</levelLimit></stats><br><br><consumable>Click to Consume:</consumable> Grants +30 Attack Damage and <font color='#FF8811'><u>Bloodlust</u></font> for 3 minutes.<br><br><font color='#FF8811'><u>Bloodlust:</u></font> Dealing physical damage to champions heals for 15% of the damage dealt.<br><br><rules>(Only one Elixir effect may be active at a time.)</rules>",
           "colloq": ";red",
           "plaintext": "Temporarily grants Attack Damage and heals you when dealing physical damage to champions.",
@@ -9581,7 +9558,6 @@
         },
         "2301": {
           "name": "Eye of the Watchers",
-          "group": "GoldBase",
           "description": "<stats>+200 Health<br><mana>+100% Base Mana Regen </mana><br>+25 Ability Power<br>+10% Cooldown Reduction<br>+2 Gold per 10 seconds</stats><br><br><unique>UNIQUE Passive - Tribute:</unique> Spells and basic attacks against champions or buildings deal 15 additional damage and grant 15 Gold. This can occur up to 3 times every 30 seconds.<br><active>UNIQUE Active - Warding:</active> Consumes a charge to place a <font color='#BBFFFF'>Stealth Ward</font> that reveals the surrounding area for 150 seconds. Holds up to 4 charges which refill upon visiting the shop. <br><br><groupLimit>Limited to 1 Gold Income Item.</groupLimit><br><br><rules>(A player may only have 3 <font color='#BBFFFF'>Stealth Wards</font> on the map at one time. Unique Passives with the same name don't stack.)</rules>",
           "colloq": ";",
           "plaintext": "Provides Ability Power and Stealth Wards over time",
@@ -9640,8 +9616,7 @@
         },
         "2302": {
           "name": "Eye of the Oasis",
-          "group": "GoldBase",
-          "description": "<stats>+200 Health<br>+150% Base Health Regen <br><mana>+100% Base Mana Regen </mana><br>+10% Cooldown Reduction</stats><br><br><unique>UNIQUE Passive - Favor:</unique> Being near a minion's death without dealing the killing blow grants 6 Gold and 10 Health.<br><active>UNIQUE Active - Warding:</active> Consumes a charge to place a <font color='#BBFFFF'>Stealth Ward</font> that reveals the surrounding area for 150 seconds. Holds up to 4 charges which refill upon visiting the shop.<br><br><groupLimit>Limited to 1 Gold Income Item.</groupLimit><br><br><rules>(A player may only have 3 <font color='#BBFFFF'>Stealth Wards</font> on the map at one time. Unique Passives with the same name don't stack.)</rules>",
+          "description": "<stats>+200 Health<br>+100% Base Health Regen <br><mana>+100% Base Mana Regen </mana><br>+10% Cooldown Reduction</stats><br><br><unique>UNIQUE Passive - Favor:</unique> Being near a minion's death without dealing the killing blow grants 6 Gold and 10 Health.<br><active>UNIQUE Active - Warding:</active> Consumes a charge to place a <font color='#BBFFFF'>Stealth Ward</font> that reveals the surrounding area for 150 seconds. Holds up to 4 charges which refill upon visiting the shop.<br><br><groupLimit>Limited to 1 Gold Income Item.</groupLimit><br><br><rules>(A player may only have 3 <font color='#BBFFFF'>Stealth Wards</font> on the map at one time. Unique Passives with the same name don't stack.)</rules>",
           "colloq": ";",
           "plaintext": "Provides Regeneration and Stealth Wards over time",
           "from": [
@@ -9659,10 +9634,10 @@
             "h": 48
           },
           "gold": {
-            "base": 550,
+            "base": 250,
             "purchasable": true,
-            "total": 2200,
-            "sell": 880
+            "total": 1900,
+            "sell": 760
           },
           "tags": [
             "Active",
@@ -9697,8 +9672,7 @@
         },
         "2303": {
           "name": "Eye of the Equinox",
-          "group": "GoldBase",
-          "description": "<stats>+500 Health<br>+100% Base Health Regen <br>+2 Gold per 10 seconds</stats><br><br><unique>UNIQUE Passive - Spoils of War:</unique> Melee basic attacks execute minions below 320 (+20 per level) Health. Killing a minion heals the owner and the nearest allied champion for 50 Health and grants them kill Gold. These effects require a nearby ally. Recharges every 30 seconds. Max 4 charges.<br><active>UNIQUE Active - Warding:</active> Consumes a charge to place a <font color='#BBFFFF'>Stealth Ward</font> that reveals the surrounding area for 150 seconds. Holds up to 4 charges which refill upon visiting the shop.<br><br><groupLimit>Limited to 1 Gold Income Item.</groupLimit><br><br><rules>(A player may only have 3 <font color='#BBFFFF'>Stealth Wards</font> on the map at one time. Unique Passives with the same name don't stack.)</rules>",
+          "description": "<stats>+500 Health<br>+200% Base Health Regen <br>+2 Gold per 10 seconds</stats><br><br><unique>UNIQUE Passive - Spoils of War:</unique> Melee basic attacks execute minions below 320 (+20 per level) Health. Killing a minion heals the owner and the nearest allied champion for 50 Health and grants them kill Gold. These effects require a nearby ally. Recharges every 30 seconds. Max 4 charges.<br><active>UNIQUE Active - Warding:</active> Consumes a charge to place a <font color='#BBFFFF'>Stealth Ward</font> that reveals the surrounding area for 150 seconds. Holds up to 4 charges which refill upon visiting the shop.<br><br><groupLimit>Limited to 1 Gold Income Item.</groupLimit><br><br><rules>(A player may only have 3 <font color='#BBFFFF'>Stealth Wards</font> on the map at one time. Unique Passives with the same name don't stack.)</rules>",
           "colloq": ";",
           "plaintext": "Provides Health and Stealth Wards over time",
           "from": [
@@ -9753,9 +9727,9 @@
         },
         "3001": {
           "name": "Abyssal Scepter",
-          "description": "<stats>+60 Ability Power<br>+60 Magic Resist<br>+10% Cooldown Reduction</stats><br><br><aura>UNIQUE Aura:</aura> Reduces the Magic Resist of nearby enemy champions by <levelScale>10 - 25</levelScale>.",
+          "description": "<stats>+60 Ability Power<br>+60 Magic Resist<br>+10% Cooldown Reduction</stats><br><br><aura>UNIQUE Aura:</aura> Nearby enemy champions take 10% more magic damage.",
           "colloq": ";",
-          "plaintext": "Reduces Magic Resist of nearby enemies",
+          "plaintext": "Nearby enemies take more magic damage",
           "from": [
             "3108",
             "1057",
@@ -9798,7 +9772,8 @@
           },
           "effect": {
             "Effect1Amount": "-10",
-            "Effect2Amount": "-25"
+            "Effect2Amount": "-25",
+            "Effect3Amount": "0.1"
           },
           "depth": 3
         },
@@ -9915,7 +9890,6 @@
         },
         "3006": {
           "name": "Berserker's Greaves",
-          "group": "BootsUpgrades",
           "description": "<stats> +35% Attack Speed</stats><br><br><unique>UNIQUE Passive - Enhanced Movement:</unique> +45 Movement Speed",
           "colloq": ";",
           "plaintext": "Enhances Movement Speed and Attack Speed",
@@ -10073,7 +10047,6 @@
         },
         "3009": {
           "name": "Boots of Swiftness",
-          "group": "BootsUpgrades",
           "description": "<unique>UNIQUE Passive - Enhanced Movement:</unique> +55 Movement Speed<br><unique>UNIQUE Passive - Slow Resist:</unique> Movement slowing effects are reduced by 25%.",
           "colloq": ";",
           "plaintext": "Enhances Movement Speed and reduces the effect of slows",
@@ -10178,7 +10151,6 @@
         },
         "3020": {
           "name": "Sorcerer's Shoes",
-          "group": "BootsUpgrades",
           "description": "<stats>+15 <a href='FlatMagicPen'>Magic Penetration</a></stats><br><br><unique>UNIQUE Passive - Enhanced Movement:</unique> +45 Movement Speed",
           "colloq": ";",
           "plaintext": "Enhances Movement Speed and magic damage",
@@ -10287,6 +10259,7 @@
             "3110",
             "3025",
             "3050",
+            "3060",
             "3187"
           ],
           "image": {
@@ -10412,7 +10385,7 @@
             "8": true,
             "10": false,
             "11": true,
-            "12": false,
+            "12": true,
             "14": false
           },
           "stats": {
@@ -10486,7 +10459,7 @@
         },
         "3028": {
           "name": "Chalice of Harmony",
-          "description": "<stats>+25 Magic Resist<br><mana>+50% Base Mana Regen </mana></stats><br><br><unique>UNIQUE Passive:</unique> Increases Base Health Regeneration by 100% if current Health % is lower than current Mana %.  <br><br>Increases Base Mana Regeneration by 100% if current Mana % is lower than current Health %.",
+          "description": "<stats>+25 Magic Resist<br><mana>+50% Base Mana Regen </mana></stats><br><br><unique>UNIQUE Passive:</unique> Grants bonus % Base Health Regen equal to your bonus % Base Mana Regen.</unique>",
           "colloq": ";",
           "plaintext": "Increases Mana and Health Regeneration",
           "from": [
@@ -10508,10 +10481,10 @@
             "h": 48
           },
           "gold": {
-            "base": 200,
+            "base": 100,
             "purchasable": true,
-            "total": 900,
-            "sell": 630
+            "total": 800,
+            "sell": 560
           },
           "tags": [
             "HealthRegen",
@@ -11197,7 +11170,6 @@
         },
         "3047": {
           "name": "Ninja Tabi",
-          "group": "BootsUpgrades",
           "description": "<stats>+30 Armor</stats><br><br><unique>UNIQUE Passive:</unique> Blocks 12% of the damage from basic attacks.<br><unique>UNIQUE Passive - Enhanced Movement:</unique> +45 Movement Speed",
           "colloq": ";",
           "plaintext": "Enhances Movement Speed and reduces incoming basic attack damage",
@@ -11318,10 +11290,10 @@
             "h": 48
           },
           "gold": {
-            "base": 480,
+            "base": 380,
             "purchasable": true,
-            "total": 2350,
-            "sell": 1645
+            "total": 2250,
+            "sell": 1575
           },
           "tags": [
             "Active",
@@ -11500,7 +11472,7 @@
             "8": false,
             "10": false,
             "11": true,
-            "12": false,
+            "12": true,
             "14": false
           },
           "stats": {
@@ -11567,12 +11539,12 @@
         },
         "3060": {
           "name": "Banner of Command",
-          "description": "<stats>+200 Health<br>+100% Base Health Regen <br>+60 Ability Power<br>+20 Magic Resist<br>+10% Cooldown Reduction</stats><br><br><aura>UNIQUE Aura - Legion:</aura> Grants nearby allies +15 Magic Resist.<br><active>UNIQUE Active - Promote:</active> Greatly increases the power of a lane minion and grants it immunity to magic damage (120 second cooldown).",
+          "description": "<stats>+60 Armor<br>+30 Magic Resist<br><mana>+400 Mana</mana><br>+10% Cooldown Reduction</stats><br><br><active>UNIQUE Active - Promote:</active> Greatly increases the power of a lane minion and grants it immunity to magic damage (120 second cooldown).",
           "colloq": ";flag",
           "plaintext": "Promotes a siege minion to a more powerful unit",
           "from": [
             "3105",
-            "3108"
+            "3024"
           ],
           "into": [],
           "image": {
@@ -11585,19 +11557,17 @@
             "h": 48
           },
           "gold": {
-            "base": 600,
+            "base": 100,
             "purchasable": true,
-            "total": 3000,
-            "sell": 2100
+            "total": 2200,
+            "sell": 1540
           },
           "tags": [
             "Active",
-            "Aura",
+            "Armor",
             "CooldownReduction",
-            "Health",
-            "HealthRegen",
-            "SpellBlock",
-            "SpellDamage"
+            "Mana",
+            "SpellBlock"
           ],
           "maps": {
             "1": false,
@@ -11608,16 +11578,16 @@
             "14": false
           },
           "stats": {
-            "FlatHPPoolMod": 200,
-            "FlatMagicDamageMod": 60,
-            "FlatSpellBlockMod": 20
+            "FlatMPPoolMod": 400,
+            "FlatArmorMod": 60,
+            "FlatSpellBlockMod": 30
           },
           "effect": {
             "Effect1Amount": "0.5",
             "Effect2Amount": "15",
             "Effect3Amount": "0.75"
           },
-          "depth": 4
+          "depth": 3
         },
         "3065": {
           "name": "Spirit Visage",
@@ -11680,7 +11650,6 @@
           ],
           "into": [
             "3187",
-            "3190",
             "3401",
             "3065",
             "3056",
@@ -11772,7 +11741,6 @@
         },
         "3069": {
           "name": "Talisman of Ascension",
-          "group": "GoldBase",
           "description": "<stats>+45 Armor<br>+150% Base Health Regen <br><mana>+75% Base Mana Regen <br></mana>+10% Cooldown Reduction</stats><br><br><unique>UNIQUE Passive - Point Runner:</unique> Builds up to +20% Movement Speed over 2 seconds while near turrets, fallen turrets and Void Gates.<br><unique>UNIQUE Passive - Favor:</unique> Being near a minion's death without dealing the killing blow grants 6 Gold and 10 Health.<br><active>UNIQUE Active:</active> Grants nearby allies +40% Movement Speed for 3 seconds (60 second cooldown).<br><br><groupLimit>Limited to 1 Gold Income Item.</groupLimit><br><br><rules><font color='#447777'>''Praise the sun.'' - Historian Shurelya, 22 September, 25 CLE</font></rules>",
           "colloq": ";shurelya;reverie",
           "plaintext": "Increases Health / Mana Regeneration and Cooldown Reduction. Activate to speed up nearby allies.",
@@ -11791,10 +11759,10 @@
             "h": 48
           },
           "gold": {
-            "base": 450,
+            "base": 350,
             "purchasable": true,
-            "total": 2500,
-            "sell": 1000
+            "total": 2400,
+            "sell": 960
           },
           "tags": [
             "Active",
@@ -12610,7 +12578,7 @@
         },
         "3090": {
           "name": "Wooglet's Witchcap",
-          "description": "<stats>+100 Ability Power<br>+45 Armor  </stats><br><br><unique>UNIQUE Passive:</unique> Increases Ability Power by 25%<br><active>UNIQUE Active:</active> Champion becomes invulnerable and untargetable for 2.5 seconds, but is unable to move, attack, cast spells, or use items during this time (90 second cooldown).",
+          "description": "<stats>+100 Ability Power<br>+45 Armor  </stats><br><br><unique>UNIQUE Passive:</unique> Increases Ability Power by 25%<br><active>UNIQUE Active:</active> Champion becomes invulnerable and untargetable for 2.5 seconds, but is unable to move, attack, cast spells, or use items during this time (120 second cooldown).",
           "colloq": ";hat",
           "plaintext": "Massively increases Ability Power and can be activated to enter stasis",
           "from": [
@@ -12653,7 +12621,7 @@
           "effect": {
             "Effect1Amount": "25",
             "Effect2Amount": "2.5",
-            "Effect3Amount": "90"
+            "Effect3Amount": "120"
           },
           "depth": 3
         },
@@ -12709,7 +12677,6 @@
         },
         "3092": {
           "name": "Frost Queen's Claim",
-          "group": "GoldBase",
           "description": "<stats>+50 Ability Power<br>+10% Cooldown Reduction<br>+2 Gold per 10 seconds<br><mana>+75% Base Mana Regen </mana></stats><br><br><unique>UNIQUE Passive - Tribute:</unique> Spells and basic attacks against champions or buildings deal 15 additional damage and grant 15 Gold. This can occur up to 3 times every 30 seconds.<br><active>UNIQUE Active:</active> Summon 2 icy ghosts for 6 seconds that seek out nearby enemy champions. Ghosts reveal enemies on contact and reduce their Movement Speed by 40% for between 2 and 5 seconds based on how far the ghosts have traveled (90 second cooldown).<br><br><groupLimit>Limited to 1 Gold Income Item.</groupLimit>",
           "colloq": "spooky ghosts;",
           "plaintext": "Sends out seeking wraiths that track hidden enemies and slow them",
@@ -12819,7 +12786,6 @@
         },
         "3096": {
           "name": "Nomad's Medallion",
-          "group": "GoldBase",
           "description": "<stats>+25% Base Health Regen <br><mana>+75% Base Mana Regen </mana><br>+10% Cooldown Reduction</stats><br><br><unique>UNIQUE Passive - Favor:</unique> Being near a minion's death without dealing the killing blow grants 6 Gold and 10 Health.<br><br><groupLimit>Limited to 1 Gold Income Item.</groupLimit><br><br><rules><font color='#447777'>''The medallion shines with the glory of a thousand voices when exposed to the sun.'' - Historian Shurelya, 22 June, 24 CLE</font></rules>",
           "colloq": ";",
           "plaintext": "Grants gold when nearby enemy minions die, Health Regen and Mana Regen",
@@ -12872,7 +12838,6 @@
         },
         "3097": {
           "name": "Targon's Brace",
-          "group": "GoldBase",
           "description": "<stats>+175 Health<br>+50% Base Health Regen <br>+2 Gold per 10 seconds </stats><br><br><unique>UNIQUE Passive - Spoils of War:</unique> Melee basic attacks execute minions below 200 (+10 per level) Health. Killing a minion heals the owner and the nearest allied champion for 40 Health and grants them kill Gold.<br><br>These effects require a nearby ally. Recharges every 30 seconds. Max 3 charges.<br><br><groupLimit>Limited to 1 Gold Income Item.</groupLimit>",
           "colloq": ";",
           "plaintext": "Periodically kill enemy minions to heal and grant gold to a nearby ally",
@@ -12928,7 +12893,6 @@
         },
         "3098": {
           "name": "Frostfang",
-          "group": "GoldBase",
           "description": "<stats>+15 Ability Power<br>+2 Gold per 10 seconds<br><mana>+75% Base Mana Regen </mana></stats><br><br><unique>UNIQUE Passive - Tribute:</unique> Spells and basic attacks against champions or buildings deal 15 additional damage and grant 15 Gold. This can occur up to 3 times every 30 seconds. Killing a minion disables this passive for 12 seconds.<br><br><groupLimit>Limited to 1 Gold Income Item.</groupLimit>",
           "colloq": ";",
           "plaintext": "Grants gold when you damage an enemy with a Spell or Attack",
@@ -13186,12 +13150,12 @@
         },
         "3105": {
           "name": "Aegis of the Legion",
-          "description": "<stats>+200 Health<br>+100% Base Health Regen <br>+20 Magic Resist</stats><br><br><aura>UNIQUE Aura - Legion:</aura> Grants nearby allies +10 Magic Resist.",
+          "description": "<stats>+30 Armor<br>+30 Magic Resist</stats>",
           "colloq": ";",
-          "plaintext": "Improves defenses for nearby allies",
+          "plaintext": "Grants Armor and Magic Resistance",
           "from": [
             "1033",
-            "3801"
+            "1029"
           ],
           "into": [
             "3190",
@@ -13207,15 +13171,13 @@
             "h": 48
           },
           "gold": {
-            "base": 400,
+            "base": 350,
             "purchasable": true,
-            "total": 1500,
-            "sell": 1050
+            "total": 1100,
+            "sell": 770
           },
           "tags": [
-            "Aura",
-            "Health",
-            "HealthRegen",
+            "Armor",
             "SpellBlock"
           ],
           "maps": {
@@ -13227,12 +13189,62 @@
             "14": false
           },
           "stats": {
-            "FlatHPPoolMod": 200,
-            "FlatSpellBlockMod": 20
+            "FlatArmorMod": 30,
+            "FlatSpellBlockMod": 30
+          },
+          "depth": 2
+        },
+        "3107": {
+          "name": "Redemption",
+          "description": "<stats>+400 Health<br>+75% Base Health Regen <br>+75% Base Mana Regen <br>+10% Cooldown Reduction</stats><br><br><passive>UNIQUE Passive:</passive> +10% Heal and Shield Power<br><active>UNIQUE Active:</active> Target an area within 5500 range. After 2.5 seconds, call down a beam of light to heal allies for 130 (+20 per level of target) Health, burn enemy champions for 10% of their maximum Health as <font color='#FFFFFF'>true</font> damage and deal 250 <font color='#FFFFFF'>true</font> damage to enemy minions (120 second cooldown).<br><br>Can be used while dead.<br><br><rules>(Half effect if the target has been affected by another Redemption recently.)</rules>",
+          "colloq": ";",
+          "plaintext": "Further improves defenses for nearby allies",
+          "from": [
+            "3114",
+            "3801"
+          ],
+          "into": [],
+          "image": {
+            "full": "3107.png",
+            "sprite": "item2.png",
+            "group": "item",
+            "x": 192,
+            "y": 192,
+            "w": 48,
+            "h": 48
+          },
+          "gold": {
+            "base": 650,
+            "purchasable": true,
+            "total": 2100,
+            "sell": 1470
+          },
+          "tags": [
+            "CooldownReduction",
+            "Health",
+            "HealthRegen",
+            "ManaRegen"
+          ],
+          "maps": {
+            "1": false,
+            "8": true,
+            "10": true,
+            "11": true,
+            "12": true,
+            "14": false
+          },
+          "stats": {
+            "FlatHPPoolMod": 400
           },
           "effect": {
-            "Effect1Amount": "10",
-            "Effect2Amount": "0.75"
+            "Effect1Amount": "0.1",
+            "Effect2Amount": "130",
+            "Effect3Amount": "20",
+            "Effect4Amount": "0.1",
+            "Effect5Amount": "250",
+            "Effect6Amount": "120",
+            "Effect7Amount": "550",
+            "Effect8Amount": "5500"
           },
           "depth": 3
         },
@@ -13249,7 +13261,6 @@
             "3092",
             "3115",
             "3165",
-            "3060",
             "3001",
             "3157"
           ],
@@ -13288,6 +13299,62 @@
           },
           "depth": 2
         },
+        "3109": {
+          "name": "Knight's Vow",
+          "description": "<stats>+400 Health<br>+100% Base Health Regen <br>+20 Armor</stats><br><br><active>UNIQUE Active:</active> Designate an allied champion as your <a href='KnightsVowPartner'>Partner</a> (90 second cooldown).<br><passive>UNIQUE Passive:</passive> If your <a href='KnightsVowPartner'>Partner</a> is nearby, gain +40 additional Armor and +15% Movement Speed towards them.<br><passive>UNIQUE Passive:</passive> If your <a href='KnightsVowPartner'>Partner</a> is nearby, heal for 12% of the damage your <a href='KnightsVowPartner'>Partner</a> deals to champions and redirect 12% of the damage your <a href='KnightsVowPartner'>Partner</a> takes from champions to you as <font color='#FFFFFF'>true</font> damage (healing and damage redirection are reduced by 50% if you are ranged).<br><br><rules>(Champions can only be linked by one Knight's Vow at a time.)</rules>",
+          "colloq": ";",
+          "plaintext": "Partner with an ally to protect each other",
+          "from": [
+            "3801",
+            "1029",
+            "3801"
+          ],
+          "into": [],
+          "image": {
+            "full": "3109.png",
+            "sprite": "item2.png",
+            "group": "item",
+            "x": 240,
+            "y": 192,
+            "w": 48,
+            "h": 48
+          },
+          "gold": {
+            "base": 800,
+            "purchasable": true,
+            "total": 2400,
+            "sell": 1680
+          },
+          "tags": [
+            "Armor",
+            "Aura",
+            "Health",
+            "HealthRegen",
+            "NonbootsMovement"
+          ],
+          "maps": {
+            "1": false,
+            "8": true,
+            "10": true,
+            "11": true,
+            "12": true,
+            "14": false
+          },
+          "stats": {
+            "FlatHPPoolMod": 400,
+            "FlatArmorMod": 20
+          },
+          "effect": {
+            "Effect1Amount": "40",
+            "Effect2Amount": "0.15",
+            "Effect3Amount": "0.12",
+            "Effect4Amount": "0.12",
+            "Effect5Amount": "90",
+            "Effect6Amount": "0.5",
+            "Effect7Amount": "900"
+          },
+          "depth": 3
+        },
         "3110": {
           "name": "Frozen Heart",
           "description": "<stats>+90 Armor<br>+20% Cooldown Reduction<br><mana>+400 Mana</mana></stats><br><br><aura>UNIQUE Aura:</aura> Reduces the Attack Speed of nearby enemies by 15%.",
@@ -13308,10 +13375,10 @@
             "h": 48
           },
           "gold": {
-            "base": 800,
+            "base": 700,
             "purchasable": true,
-            "total": 2800,
-            "sell": 1960
+            "total": 2700,
+            "sell": 1890
           },
           "tags": [
             "Armor",
@@ -13339,7 +13406,6 @@
         },
         "3111": {
           "name": "Mercury's Treads",
-          "group": "BootsUpgrades",
           "description": "<stats>+25 Magic Resist</stats><br><br><unique>UNIQUE Passive - Enhanced Movement:</unique> +45 Movement Speed<br><unique>UNIQUE Passive - Tenacity:</unique> Reduces the duration of stuns, slows, taunts, fears, silences, blinds, polymorphs, and immobilizes by 30%.",
           "colloq": ";",
           "plaintext": "Increases Movement Speed and reduces duration of disabling effects",
@@ -13387,7 +13453,6 @@
         },
         "3112": {
           "name": "Guardian's Orb",
-          "group": "GuardianItems",
           "description": "<stats>+150 Health<br>+30 Ability Power<br><mana>+10 Mana regen per 5 seconds</mana></stats><br><br><groupLimit>Limited to 1 Guardian's Item.</groupLimit>",
           "colloq": ";",
           "plaintext": "Good starting item for mages",
@@ -13482,7 +13547,7 @@
         },
         "3114": {
           "name": "Forbidden Idol",
-          "description": "<stats><mana>+50% Base Mana Regen </mana></stats><br><br><unique>UNIQUE Passive:</unique> +10% Cooldown Reduction<br><unique>UNIQUE Passive:</unique> +10% Heal and Shield Power",
+          "description": "<stats><mana>+50% Base Mana Regen </mana></stats><br><br><unique>UNIQUE Passive:</unique> +10% Cooldown Reduction<br><unique>UNIQUE Passive:</unique> +8% Heal and Shield Power",
           "colloq": ";",
           "plaintext": "Increases Mana Regeneration and Cooldown Reduction",
           "from": [
@@ -13490,6 +13555,7 @@
             "1004"
           ],
           "into": [
+            "3107",
             "3222",
             "3504"
           ],
@@ -13503,10 +13569,10 @@
             "h": 48
           },
           "gold": {
-            "base": 600,
+            "base": 550,
             "purchasable": true,
-            "total": 850,
-            "sell": 595
+            "total": 800,
+            "sell": 560
           },
           "tags": [
             "CooldownReduction",
@@ -13523,7 +13589,7 @@
           "stats": {},
           "effect": {
             "Effect1Amount": "-0.1",
-            "Effect2Amount": "0.1"
+            "Effect2Amount": "0.08"
           },
           "depth": 2
         },
@@ -13627,7 +13693,6 @@
         },
         "3117": {
           "name": "Boots of Mobility",
-          "group": "BootsUpgrades",
           "description": "<unique>UNIQUE Passive - Enhanced Movement:</unique> +25 Movement Speed. Increases to +115 Movement Speed when out of combat for 5 seconds.",
           "colloq": ";",
           "plaintext": "Greatly enhances Movement Speed when out of combat",
@@ -13848,6 +13913,7 @@
             "1412",
             "3071",
             "3104",
+            "3156",
             "3508",
             "3671",
             "3812"
@@ -13889,9 +13955,9 @@
         },
         "3134": {
           "name": "Serrated Dirk",
-          "description": "<stats>+20 Attack Damage</stats><br><br><unique>UNIQUE Passive:</unique> +10 <a href='FlatArmorPen'>Armor Penetration</a><br><unique>UNIQUE Passive:</unique> After killing any unit, your next basic attack or single target spell deals +15 damage.",
-          "colloq": ";",
-          "plaintext": "Increases Attack Damage and Armor Penetration",
+          "description": "<stats>+25 Attack Damage</stats><br><br><unique>UNIQUE Passive:</unique> +10 <a href='Lethality'>Lethality</a><br><unique>UNIQUE Passive:</unique> +20 Movement Speed out of Combat.",
+          "colloq": ";lethality",
+          "plaintext": "Increases Attack Damage and Lethality",
           "stacks": 0,
           "from": [
             "1036",
@@ -13900,7 +13966,7 @@
           "into": [
             "3142",
             "3147",
-            "3156"
+            "3814"
           ],
           "image": {
             "full": "3134.png",
@@ -13919,7 +13985,8 @@
           },
           "tags": [
             "ArmorPenetration",
-            "Damage"
+            "Damage",
+            "NonbootsMovement"
           ],
           "maps": {
             "1": false,
@@ -13930,11 +13997,12 @@
             "14": false
           },
           "stats": {
-            "FlatPhysicalDamageMod": 20
+            "FlatPhysicalDamageMod": 25
           },
           "effect": {
-            "Effect1Amount": "15",
-            "Effect2Amount": "10"
+            "Effect1Amount": "0",
+            "Effect2Amount": "10",
+            "Effect3Amount": "20"
           },
           "depth": 2
         },
@@ -14186,9 +14254,9 @@
         },
         "3142": {
           "name": "Youmuu's Ghostblade",
-          "description": "<stats>+60 Attack Damage<br>+10% Cooldown Reduction</stats><br><br><unique>UNIQUE Passive:</unique> +20 <a href='FlatArmorPen'>Armor Penetration</a><br><active>UNIQUE Active:</active> Grants +20% Movement Speed and +40% Attack Speed for 6 seconds (45 second cooldown).",
-          "colloq": ";",
-          "plaintext": "Activate to greatly increase Movement Speed and Attack Speed",
+          "description": "<stats>+60 Attack Damage<br>+10% Cooldown Reduction</stats><br><br><unique>UNIQUE Passive:</unique> +20 <a href='Lethality'>Lethality</a><br><unique>UNIQUE Passive:</unique> +20 Movement Speed out of Combat<br><active>UNIQUE Active:</active> Grants +20% Movement Speed for 6 seconds (45 second cooldown).",
+          "colloq": ";lethality",
+          "plaintext": "Activate to greatly increase Movement Speed",
           "from": [
             "3133",
             "3134"
@@ -14204,15 +14272,14 @@
             "h": 48
           },
           "gold": {
-            "base": 1000,
+            "base": 700,
             "purchasable": true,
-            "total": 3200,
-            "sell": 2240
+            "total": 2900,
+            "sell": 2030
           },
           "tags": [
             "Active",
             "ArmorPenetration",
-            "AttackSpeed",
             "CooldownReduction",
             "Damage",
             "NonbootsMovement"
@@ -14232,8 +14299,9 @@
             "Effect1Amount": "45",
             "Effect2Amount": "20",
             "Effect3Amount": "0.2",
-            "Effect4Amount": "0.4",
-            "Effect5Amount": "6"
+            "Effect4Amount": "0",
+            "Effect5Amount": "6",
+            "Effect6Amount": "20"
           },
           "depth": 3
         },
@@ -14344,7 +14412,7 @@
         },
         "3145": {
           "name": "Hextech Revolver",
-          "description": "<stats>+40 Ability Power</stats><br><br><unique>UNIQUE Passive - Magic Bolt:</unique> Damaging an enemy champion with a basic attack shocks them for <levelScale>75 - 150</levelScale> bonus magic damage (40 second cooldown, shared with other <font color='#9999FF'><a href='itembolt'>Hextech</a></font> items).<br><br>Magic Bolt's cooldown is reduced by Active Item cooldown reduction.<br><br><rules>(Damage scales based on level. Hextech effects can trigger other item spell effects.)</rules>",
+          "description": "<stats>+40 Ability Power</stats><br><br><unique>UNIQUE Passive - Magic Bolt:</unique> Damaging an enemy champion with a basic attack shocks them for <levelScale>50 - 125</levelScale> bonus magic damage (40 second cooldown, shared with other <font color='#9999FF'><a href='itembolt'>Hextech</a></font> items).<br><br>Magic Bolt's cooldown is reduced by Active Item cooldown reduction.<br><br><rules>(Damage scales based on level. Hextech effects can trigger other item spell effects.)</rules>",
           "colloq": ";",
           "plaintext": "Increases Ability Power. Deal bonus magic damage on attack periodically.",
           "from": [
@@ -14387,9 +14455,9 @@
           },
           "effect": {
             "Effect1Amount": "0",
-            "Effect2Amount": "75",
+            "Effect2Amount": "50",
             "Effect3Amount": "0",
-            "Effect4Amount": "150",
+            "Effect4Amount": "125",
             "Effect5Amount": "40"
           },
           "depth": 2
@@ -14448,9 +14516,9 @@
         },
         "3147": {
           "name": "Duskblade of Draktharr",
-          "description": "<stats>+75 Attack Damage<br>+5% Movement Speed</stats><br><br><unique>UNIQUE Passive:</unique> +10 <a href='FlatArmorPen'>Armor Penetration</a><br><unique>UNIQUE Passive:</unique> Basic Attacks on an enemy champion apply <unlockedPassive>Nightfall</unlockedPassive> (120 second cooldown).<br><br><unlockedPassive>Nightfall:</unlockedPassive> After 2 seconds, deal physical damage equal to 90 plus 25% of the target's missing health. If you get a kill or assist on the target before Nightfall ends, the cooldown is refunded.",
-          "colloq": ";",
-          "plaintext": "Deals a delayed burst of damage on hit.",
+          "description": "<stats>+65 Attack Damage</stats><br><br><unique>UNIQUE Passive:</unique> +15 <a href='Lethality'>Lethality</a><br><unique>UNIQUE Passive:</unique> +20 Movement Speed out of Combat.<br><unique>UNIQUE Passive - Nightstalker:</unique> After being unseen for at least 1 second, your next Basic Attack against an enemy champion will deal 50 (+200% Lethality) true damage on-hit (lasts for 4 seconds after being seen by an enemy champion).<br><unique>UNIQUE Passive - Blackout:</unique> When spotted by an enemy ward, causes a blackout for 8 seconds, disabling all nearby enemy wards (90 second cooldown).",
+          "colloq": ";lethality",
+          "plaintext": "Deals additional true damage on-hit and provides true sight periodically",
           "from": [
             "3134",
             "1038"
@@ -14486,17 +14554,15 @@
             "14": false
           },
           "stats": {
-            "FlatPhysicalDamageMod": 75,
-            "PercentMovementSpeedMod": 0.05
+            "FlatPhysicalDamageMod": 65
           },
           "effect": {
-            "Effect1Amount": "10",
-            "Effect2Amount": "0",
-            "Effect3Amount": "2",
-            "Effect4Amount": "0.25",
-            "Effect5Amount": "120",
-            "Effect6Amount": "60",
-            "Effect7Amount": "90"
+            "Effect1Amount": "15",
+            "Effect2Amount": "20",
+            "Effect3Amount": "0",
+            "Effect4Amount": "90",
+            "Effect5Amount": "50",
+            "Effect6Amount": "2"
           },
           "depth": 3
         },
@@ -14554,7 +14620,7 @@
         },
         "3152": {
           "name": "Hextech Protobelt-01",
-          "description": "<stats>+300 Health<br>+60 Ability Power<br>+10% Cooldown Reduction</stats><br><br><unique>UNIQUE Active - Fire Bolt:</unique> Dash forward and unleash a nova of fire bolts that deal <levelScale>75 - 150</levelScale> (+35% of your Ability Power) as magic damage (40 second cooldown, shared with other <font color='#9999FF'><a href='itembolt'>Hextech</a></font> items).<br><br>Champions and Monsters hit by multiple fire bolts take 20% damage per additional bolt.<br><br><rules>(This dash cannot pass through terrain.)</rules>",
+          "description": "<stats>+300 Health<br>+60 Ability Power<br>+10% Cooldown Reduction</stats><br><br><unique>UNIQUE Active - Fire Bolt:</unique> Dash forward and unleash a nova of fire bolts that deal <levelScale>75 - 150</levelScale> (+25% of your Ability Power) as magic damage (40 second cooldown, shared with other <font color='#9999FF'><a href='itembolt'>Hextech</a></font> items).<br><br>Champions and Monsters hit by multiple fire bolts take 10% damage per additional bolt.<br><br><rules>(This dash cannot pass through terrain.)</rules>",
           "colloq": "rocket belt;",
           "plaintext": "Activate to dash forward and unleash a fiery explosion",
           "from": [
@@ -14601,8 +14667,8 @@
             "Effect3Amount": "40",
             "Effect4Amount": "75",
             "Effect5Amount": "150",
-            "Effect6Amount": "0.2",
-            "Effect7Amount": "0.35",
+            "Effect6Amount": "0.1",
+            "Effect7Amount": "0.25",
             "Effect8Amount": "40"
           },
           "depth": 3
@@ -14715,13 +14781,13 @@
         },
         "3156": {
           "name": "Maw of Malmortius",
-          "description": "<stats>+55 Attack Damage<br>+40 Magic Resist<br>+10 <a href='FlatArmorPen'>Armor Penetration</a></stats><br><br><unique>UNIQUE Passive - Lifeline:</unique> Upon taking magic damage that would reduce Health below 30%, grants a shield that absorbs magic damage equal to 300 + 1 per bonus Magic Resistance for 5 seconds (90 second cooldown).<br><unlockedPassive>Lifegrip:</unlockedPassive> When <i>Lifeline</i> triggers, gain +10% Spell Vamp and +10% Life Steal until out of combat.",
+          "description": "<stats>+50 Attack Damage<br>+45 Magic Resist<br>+10% Cooldown Reduction</stats><br><br><unique>UNIQUE Passive - Lifeline:</unique> Upon taking magic damage that would reduce Health below 30%, grants a shield that absorbs magic damage equal to 300 + 1 per bonus Magic Resistance for 5 seconds (90 second cooldown).<br><unlockedPassive>Lifegrip:</unlockedPassive> When <i>Lifeline</i> triggers, gain +20 Attack Damage, +10% Spell Vamp and +10% Life Steal until out of combat.",
           "colloq": ";",
           "plaintext": "Grants bonus Attack Damage when Health is low",
           "stacks": 0,
           "from": [
             "3155",
-            "3134"
+            "3133"
           ],
           "into": [],
           "image": {
@@ -14740,7 +14806,7 @@
             "sell": 2275
           },
           "tags": [
-            "ArmorPenetration",
+            "CooldownReduction",
             "Damage",
             "LifeSteal",
             "SpellBlock",
@@ -14755,8 +14821,8 @@
             "14": false
           },
           "stats": {
-            "FlatPhysicalDamageMod": 55,
-            "FlatSpellBlockMod": 40
+            "FlatPhysicalDamageMod": 50,
+            "FlatSpellBlockMod": 45
           },
           "effect": {
             "Effect1Amount": "1",
@@ -14765,7 +14831,7 @@
             "Effect4Amount": "300",
             "Effect5Amount": "5",
             "Effect6Amount": "90",
-            "Effect7Amount": "0",
+            "Effect7Amount": "20",
             "Effect8Amount": "0"
           },
           "depth": 3
@@ -14822,7 +14888,6 @@
         },
         "3158": {
           "name": "Ionian Boots of Lucidity",
-          "group": "BootsUpgrades",
           "description": "<unique>UNIQUE Passive:</unique> +10% Cooldown Reduction<br><unique>UNIQUE Passive - Enhanced Movement:</unique> +45 Movement Speed<br><unique>UNIQUE Passive:</unique> Reduces Summoner Spell cooldowns by 10%<br><br><br><rules><font color='#FDD017'>''This item is dedicated in honor of Ionia's victory over Noxus in the Rematch for the Southern Provinces on 10 December, 20 CLE.''</font></rules>",
           "colloq": ";",
           "plaintext": "Increases Movement Speed and Cooldown Reduction",
@@ -14969,7 +15034,7 @@
         },
         "3174": {
           "name": "Athene's Unholy Grail",
-          "description": "<stats>+40 Ability Power<br>+25 Magic Resist<br>+20% Cooldown Reduction<br><mana>+75% Base Mana Regen </mana></stats><br><br><unique>UNIQUE Passive:</unique> Gain 20% of the <a href='premitigation'><font color='#6666FF'><u>premitigation</u></font></a> damage dealt to champions as Blood Charges, up to <levelScale>100 - 250</levelScale>  max. Healing or shielding another ally consumes charges to heal them, up to the original effect amount.<br><unique>UNIQUE Passive:</unique> Increases Base Health Regeneration by 100% if current Health % is lower than current Mana %. <mana>Increases Base Mana Regeneration by 100% if current Mana % is lower than current Health %.</mana><br><br><rules>(Maximum amount of Blood Charges stored is based on level. Healing amplification is applied to the total heal value.)</rules>",
+          "description": "<stats>+40 Ability Power<br>+25 Magic Resist<br>+20% Cooldown Reduction<br><mana>+75% Base Mana Regen </mana></stats><br><br><unique>UNIQUE Passive:</unique> Gain 20% of the <a href='premitigation'><font color='#6666FF'><u>premitigation</u></font></a> damage dealt to champions as Blood Charges, up to <levelScale>100 - 250</levelScale>  max. Healing or shielding another ally consumes charges to heal them, up to the original effect amount.<br><unique>UNIQUE Passive - Harmony:</unique> Grants bonus % Base Health Regen equal to your bonus % Base Mana Regen.<br><br><rules>(Maximum amount of Blood Charges stored is based on level. Healing amplification is applied to the total heal value.)</rules>",
           "colloq": ";",
           "plaintext": "Deal damage to empower your heals and shields",
           "from": [
@@ -14987,10 +15052,10 @@
             "h": 48
           },
           "gold": {
-            "base": 450,
+            "base": 400,
             "purchasable": true,
-            "total": 2250,
-            "sell": 1575
+            "total": 2100,
+            "sell": 1470
           },
           "tags": [
             "CooldownReduction",
@@ -15074,7 +15139,6 @@
         },
         "3184": {
           "name": "Guardian's Hammer",
-          "group": "GuardianItems",
           "description": "<stats>+150 Health<br>+15 Attack Damage<br>+10% Life Steal</stats><br><br><groupLimit>Limited to 1 Guardian's Item.</groupLimit>",
           "colloq": ";dblade",
           "plaintext": "Good starting item for attackers",
@@ -15228,12 +15292,12 @@
         },
         "3190": {
           "name": "Locket of the Iron Solari",
-          "description": "<stats>+400 Health<br>+100% Base Health Regen <br>+20 Magic Resist<br>+10% Cooldown Reduction</stats><br><br><active>UNIQUE Active:</active> Grants a shield to nearby allies for 2 seconds that absorbs up to 75 (+15 per level) damage (60 second cooldown). This shielding is halved for units recently shielded this way.<br><aura>UNIQUE Aura - Legion:</aura> Grants nearby allies +15 Magic Resist.",
+          "description": "<stats>+30 Armor<br>+60 Magic Resist</stats><br><br><active>UNIQUE Active:</active> Grants a decaying shield to nearby allies for 2.5 seconds that absorbs up to 35 (+35 per level) damage (90 second cooldown).<br><br><rules>(Half effect if the target has been affected by another Locket of the Iron Solari recently.)</rules>",
           "colloq": ";",
           "plaintext": "Activate to shield nearby allies from damage",
           "from": [
             "3105",
-            "3067"
+            "1033"
           ],
           "into": [],
           "image": {
@@ -15246,17 +15310,14 @@
             "h": 48
           },
           "gold": {
-            "base": 200,
+            "base": 650,
             "purchasable": true,
-            "total": 2500,
-            "sell": 1750
+            "total": 2200,
+            "sell": 1540
           },
           "tags": [
             "Active",
-            "Aura",
-            "CooldownReduction",
-            "Health",
-            "HealthRegen",
+            "Armor",
             "SpellBlock"
           ],
           "maps": {
@@ -15268,18 +15329,18 @@
             "14": false
           },
           "stats": {
-            "FlatHPPoolMod": 400,
-            "FlatSpellBlockMod": 20
+            "FlatArmorMod": 30,
+            "FlatSpellBlockMod": 60
           },
           "effect": {
-            "Effect1Amount": "15",
+            "Effect1Amount": "0",
             "Effect2Amount": "0.75",
-            "Effect3Amount": "2",
-            "Effect4Amount": "75",
-            "Effect5Amount": "15",
-            "Effect6Amount": "60"
+            "Effect3Amount": "2.5",
+            "Effect4Amount": "35",
+            "Effect5Amount": "35",
+            "Effect6Amount": "90"
           },
-          "depth": 4
+          "depth": 3
         },
         "3191": {
           "name": "Seeker's Armguard",
@@ -15563,7 +15624,7 @@
         },
         "3222": {
           "name": "Mikael's Crucible",
-          "description": "<stats>+35 Magic Resist<br>+10% Cooldown Reduction<br><mana>+150% Base Mana Regen </mana></stats><br><br><unique>UNIQUE Passive:</unique> +15% Heal and Shield Power<br><unique>UNIQUE Passive:</unique> Increases Base Health Regeneration by 100% if current Health % is lower than current Mana %. <mana>Increases Base Mana Regeneration by 100% if current Mana % is lower than current Health %.</mana><br><active>UNIQUE Active:</active> Removes all stuns, roots, taunts, fears, silences, and slows on an allied champion and heals that champion for 150 (+10% of maximum Health) (180 second cooldown).",
+          "description": "<stats>+35 Magic Resist<br>+10% Cooldown Reduction<br><mana>+150% Base Mana Regen </mana></stats><br><br><unique>UNIQUE Passive:</unique> +20% Heal and Shield Power<br><unique>UNIQUE Passive - Harmony:</unique> Grants bonus % Base Health Regen equal to your bonus % Base Mana Regen.<br><active>UNIQUE Active:</active> Cleanses all stuns, roots, taunts, fears, silences, and slows on an allied champion and grants them slow immunity for 2 seconds (120 second cooldown).<br><br>Successfully cleansing an effect this way grants the ally 40% movement speed for 2 seconds.",
           "colloq": ";",
           "plaintext": "Activate to heal and remove all disabling effects from an allied champion",
           "from": [
@@ -15581,10 +15642,10 @@
             "h": 48
           },
           "gold": {
-            "base": 650,
+            "base": 500,
             "purchasable": true,
-            "total": 2400,
-            "sell": 1680
+            "total": 2100,
+            "sell": 1470
           },
           "tags": [
             "Active",
@@ -15615,6 +15676,54 @@
             "Effect8Amount": "1"
           },
           "depth": 3
+        },
+        "3252": {
+          "name": "Poacher's Dirk",
+          "description": "<stats>+15 Attack Damage</stats><br><br><unique>UNIQUE Passive:</unique> +20 Movement Speed out of Combat<br><unique>UNIQUE Passive:</unique> After poaching 3 large monsters from the enemy jungle (60 second cooldown), transforms into a Serrated Dirk.",
+          "colloq": ";serrated dirk;lethality",
+          "plaintext": "Transforms into a Serrated Dirk after poaching in the enemy jungle.",
+          "stacks": 0,
+          "from": [
+            "1036"
+          ],
+          "into": [],
+          "image": {
+            "full": "3252.png",
+            "sprite": "item2.png",
+            "group": "item",
+            "x": 288,
+            "y": 192,
+            "w": 48,
+            "h": 48
+          },
+          "gold": {
+            "base": 400,
+            "purchasable": true,
+            "total": 750,
+            "sell": 525
+          },
+          "tags": [
+            "ArmorPenetration",
+            "Damage",
+            "NonbootsMovement"
+          ],
+          "maps": {
+            "1": false,
+            "8": false,
+            "10": true,
+            "11": true,
+            "12": false,
+            "14": false
+          },
+          "stats": {
+            "FlatPhysicalDamageMod": 15
+          },
+          "effect": {
+            "Effect1Amount": "100",
+            "Effect2Amount": "15",
+            "Effect3Amount": "20"
+          },
+          "depth": 2
         },
         "3285": {
           "name": "Luden's Echo",
@@ -15670,7 +15779,6 @@
         },
         "3301": {
           "name": "Ancient Coin",
-          "group": "GoldBase",
           "description": "<stats><mana>+25% Base Mana Regen </mana><br>+5% Cooldown Reduction</stats><br><br><unique>UNIQUE Passive - Favor:</unique> Being near a minion's death without dealing the killing blow grants 4 Gold and 5 Health.<br><br><groupLimit>Limited to 1 Gold Income Item.</groupLimit><br><br><i><font color='#447777'>''Gold dust rises from the desert and clings to the coin.'' - Historian Shurelya, 11 November, 23 CLE</font></i>",
           "colloq": ";",
           "plaintext": "Grants gold when nearby minions die that you didn't kill",
@@ -15714,7 +15822,6 @@
         },
         "3302": {
           "name": "Relic Shield",
-          "group": "GoldBase",
           "description": "<stats>+75 Health<br>+2 Gold per 10 seconds </stats><br><br><unique>UNIQUE Passive - Spoils of War:</unique> Melee basic attacks execute minions below 195 (+5 per level) Health. Killing a minion heals the owner and the nearest allied champion for 15 Health and grants them kill Gold.<br><br>These effects require a nearby ally. Recharges every 40 seconds. Max 2 charges. <br><br><groupLimit>Limited to 1 Gold Income Item.</groupLimit>",
           "colloq": ";",
           "plaintext": "Kill minions periodically to heal and grant gold to a nearby ally",
@@ -15762,7 +15869,6 @@
         },
         "3303": {
           "name": "Spellthief's Edge",
-          "group": "GoldBase",
           "description": "<stats>+5 Ability Power<br>+2 Gold per 10 seconds<br><mana>+25% Base Mana Regen </mana></stats><br><br><unique>UNIQUE Passive - Tribute:</unique> Spells and basic attacks against champions or buildings deal 10 additional damage and grant 8 Gold. This can occur up to 3 times every 30 seconds. Killing a minion disables this passive for 12 seconds.<br><br><groupLimit>Limited to 1 Gold Income Item.</groupLimit>",
           "colloq": ";",
           "plaintext": "Grants gold when you attack enemies",
@@ -15812,7 +15918,6 @@
         },
         "3340": {
           "name": "Warding Totem (Trinket)",
-          "group": "RelicBase",
           "description": "<groupLimit>Limited to 1 Trinket.</groupLimit><br><br><active>Active:</active> Consume a charge to place an invisible <font color='#BBFFFF'>Stealth Ward</font> which reveals the surrounding area for <levelScale>60 - 120</levelScale> seconds. <br><br>Stores one charge every <levelScale>180 - 90</levelScale> seconds, up to 2 maximum charges.<br><br>Ward duration and recharge time gradually improve with level.<br><br><rules>(Limit 3 <font color='#BBFFFF'>Stealth Wards</font> on the map per player. Switching to a <font color='#BBFFFF'>Lens</font> type trinket will disable <font color='#BBFFFF'>Trinket</font> use for 120 seconds.)</rules>",
           "colloq": "yellow;",
           "plaintext": "Periodically place a Stealth Ward",
@@ -15861,7 +15966,6 @@
         },
         "3341": {
           "name": "Sweeping Lens (Trinket)",
-          "group": "RelicBase",
           "description": "<groupLimit>Limited to 1 Trinket.</groupLimit><br><br><active>Active:</active> Scans an area for 6 seconds, warning against hidden hostile units and revealing / disabling invisible traps and wards (90 to 60 second cooldown).<br><br>Cast range and sweep radius gradually improve with level.<br><br><rules>(Switching to a <font color='#BBFFFF'>Totem</font>-type trinket will disable <font color='#BBFFFF'>Trinket</font> use for 120 seconds.)</rules>",
           "colloq": "red;",
           "plaintext": "Detects and disables nearby invisible wards and traps",
@@ -15909,7 +16013,6 @@
         },
         "3345": {
           "name": "Soul Anchor (Trinket)",
-          "group": "RelicBase",
           "description": "<groupLimit>Limited to 1 Trinket.</groupLimit><br><br><active>Active:</active> Consumes a charge to instantly revive at your Summoner Platform and grants 125% Movement Speed that decays over 12 seconds.<br><br><rules>Additional charges are gained at levels 9 and 14.</rules><br><br><font color='#BBFFFF'>(Max: 2 charges)</font></rules><br><br>",
           "colloq": "",
           "plaintext": "Consumes charge to revive champion.",
@@ -15947,7 +16050,6 @@
         },
         "3348": {
           "name": "Arcane Sweeper",
-          "group": "RelicBase",
           "description": "<active>UNIQUE Active - Hunter's Sight:</active> A stealth-detecting mist grants vision in the target area for 5 seconds, revealing traps and enemy champions that enter for 3 seconds (90 second cooldown).",
           "colloq": ";",
           "plaintext": "Activate to reveal a nearby area of the map",
@@ -15994,7 +16096,6 @@
         },
         "3361": {
           "name": "Greater Stealth Totem (Trinket)",
-          "group": "RelicBase",
           "description": "<groupLimit>Limited to 1 Trinket.</groupLimit><levelLimit> *Level 9+ required to upgrade.</levelLimit><stats></stats><br><br><unique>UNIQUE Active:</unique> Consume a charge to place an invisible ward that reveals the surrounding area for 180 seconds.  Stores a charge every 60 seconds, up to 2 total. Limit 3 <font color='#BBFFFF'>Stealth Wards</font> on the map per player.<br><br><rules>(Trinkets cannot be used in the first 30 seconds of a game. Selling a Trinket will disable Trinket use for 120 seconds).</rules>",
           "colloq": "yellow;",
           "plaintext": "Periodically place a Stealth Ward",
@@ -16042,7 +16143,6 @@
         },
         "3362": {
           "name": "Greater Vision Totem (Trinket)",
-          "group": "RelicBase",
           "description": "<groupLimit>Limited to 1 Trinket.</groupLimit><levelLimit> *Level 9+ required to upgrade.</levelLimit><stats></stats><br><br><unique>UNIQUE Active:</unique> Places a visible ward that reveals the surrounding area and invisible units in the area until killed (120 second cooldown). Limit 1 <font color='#BBFFFF'>Vision Ward</font> on the map per player.<br><br><rules>(Trinkets cannot be used in the first 30 seconds of a game. Selling a Trinket will disable Trinket use for 120 seconds).</rules>",
           "colloq": "yellow;",
           "plaintext": "Periodically place a Vision Ward",
@@ -16090,7 +16190,6 @@
         },
         "3363": {
           "name": "Farsight Alteration",
-          "group": "RelicBase",
           "description": "<levelLimit>* Level 9+ required to upgrade.</levelLimit><br><br>Alters the <font color='#FFFFFF'>Warding Totem</font> Trinket:<br><br><stats><font color='#00FF00'>+</font> Massively increased cast range (+650%)<br><font color='#00FF00'>+</font> Infinite duration and does not count towards ward limit<br><font color='#FF0000'>-</font> <font color='#FF6600'>10% increased cooldown</font><br><font color='#FF0000'>-</font> <font color='#FF6600'>Ward is visible, fragile, untargetable by allies</font><br><font color='#FF0000'>-</font> <font color='#FF6600'>45% reduced ward vision radius</font><br><font color='#FF0000'>-</font> <font color='#FF6600'>Cannot store charges</font></stats>",
           "colloq": "blue; totem;",
           "plaintext": "Grants increased range and reveals the targetted area",
@@ -16137,7 +16236,6 @@
         },
         "3364": {
           "name": "Oracle Alteration",
-          "group": "RelicBase",
           "description": "<levelLimit>* Level 9+ required to upgrade.</levelLimit><stats></stats><br><br>Alters the <font color='#FFFFFF'>Sweeping Lens</font> Trinket:<br><br><stats><font color='#00FF00'>+</font> Increased detection radius<br><font color='#00FF00'>+</font> Sweeping effect follows you for 10 seconds<br><font color='#FF0000'>-</font> <font color='#FF6600'>Cast range reduced to zero</font></stats>",
           "colloq": "red; lens;",
           "plaintext": "Disables nearby invisible wards and traps for a duration",
@@ -16184,8 +16282,7 @@
         },
         "3401": {
           "name": "Face of the Mountain",
-          "group": "GoldBase",
-          "description": "<stats>+450 Health<br>+100% Base Health Regen <br>+10% Cooldown Reduction<br>+2 Gold per 10 seconds </stats><br><br><unique>UNIQUE Passive - Spoils of War:</unique> Melee basic attacks execute minions below 320 (+20 per level) Health. Killing a minion heals the owner and the nearest allied champion for 50 Health and grants them kill Gold. These effects require a nearby ally. Recharges every 30 seconds. Max 4 charges.<br><unique>UNIQUE Active:</unique> Grant a shield to an ally equal to 10% of your maximum Health for 4 seconds. After 4 seconds, the shield explodes to slow nearby enemies by 40% for 2 seconds (60 second cooldown).<br><br><groupLimit>Limited to 1 Gold Income Item.</groupLimit>",
+          "description": "<stats>+450 Health<br>+100% Base Health Regen <br>+10% Cooldown Reduction<br>+2 Gold per 10 seconds </stats><br><br><unique>UNIQUE Passive - Spoils of War:</unique> Melee basic attacks execute minions below 320 (+20 per level) Health. Killing a minion heals the owner and the nearest allied champion for 50 Health and grants them kill Gold. These effects require a nearby ally. Recharges every 30 seconds. Max 4 charges.<br><unique>UNIQUE Active:</unique> Grant a shield to you and an ally equal to 10% of your maximum Health for 4 seconds. After 4 seconds, the shields explode to slow nearby enemies by 40% for 2 seconds (60 second cooldown).  Automatically targets the most wounded ally if cast upon self.<br><br><groupLimit>Limited to 1 Gold Income Item.</groupLimit>",
           "colloq": ";",
           "plaintext": "Shield an ally from damage based on your Health",
           "from": [
@@ -16240,7 +16337,6 @@
         },
         "3460": {
           "name": "Golden Transcendence",
-          "group": "RelicBase",
           "description": "<unique>Active:</unique> Use this trinket to teleport to one of the battle platforms. Can only be used from the summoning platform.<br><br><i><font color='#FDD017'>''It is at this magical precipice where a champion is dismantled, reforged, and empowered.''</font></i>",
           "colloq": ";",
           "plaintext": "",
@@ -16277,7 +16373,6 @@
         },
         "3461": {
           "name": "Golden Transcendence (Disabled)",
-          "group": "RelicBase",
           "description": "<unique>Active:</unique> Use this trinket to teleport to one of the battle platforms. Can only be used from the summoning platform.<br><br><i><font color='#FDD017'>''It is at this magical precipice where a champion is dismantled, reforged, and empowered.''</font></i>",
           "colloq": ";",
           "plaintext": "",
@@ -16314,7 +16409,6 @@
         },
         "3462": {
           "name": "Seer Stone (Trinket)",
-          "group": "RelicBase",
           "description": "<groupLimit>Limited to 1 Trinket.</groupLimit><br><br><active>Active:</active> Reveals a small area within <font color='#FFFFF'>2500</font> range for 3 seconds. Enemy champions will be revealed for 5 seconds (60 second cooldown)",
           "colloq": "blue;",
           "plaintext": "Briefly reveals a nearby targeted area",
@@ -16359,9 +16453,9 @@
         },
         "3504": {
           "name": "Ardent Censer",
-          "description": "<stats>+60 Ability Power<br>+10% Cooldown Reduction<br><mana>+50% Base Mana Regen </mana></stats><br><br><unique>UNIQUE Passive:</unique> +15% Heal and Shield Power<br><unique>UNIQUE Passive:</unique> +8% Movement Speed<br><unique>UNIQUE Passive:</unique> Your heals and shields on another allied champion grant them 15% Attack Speed and 30 magic damage on-hit for 6 seconds.<br><br><rules>(This does not include regeneration effects or effects on yourself.)</rules>",
+          "description": "<stats>+60 Ability Power<br>+10% Cooldown Reduction<br><mana>+50% Base Mana Regen </mana></stats><br><br><unique>UNIQUE Passive:</unique> +10% Heal and Shield Power<br><unique>UNIQUE Passive:</unique> +8% Movement Speed<br><unique>UNIQUE Passive:</unique> Your heals and shields on another allied champion grant them 20% Attack Speed and their attacks drain 20 health on-hit for 6 seconds.<br><br><rules>(This does not include regeneration effects or effects on yourself.)</rules>",
           "colloq": "",
-          "plaintext": "Shield and heal effects on other units grant them Attack Speed and bonus damage briefly",
+          "plaintext": "Shield and heal effects on other units grant them Attack Speed and their attacks drain life",
           "from": [
             "3114",
             "3113"
@@ -16377,10 +16471,10 @@
             "h": 48
           },
           "gold": {
-            "base": 700,
+            "base": 650,
             "purchasable": true,
-            "total": 2400,
-            "sell": 1680
+            "total": 2300,
+            "sell": 1610
           },
           "tags": [
             "CooldownReduction",
@@ -16401,10 +16495,10 @@
           },
           "effect": {
             "Effect1Amount": "0.08",
-            "Effect2Amount": "0.15",
+            "Effect2Amount": "0.2",
             "Effect3Amount": "6",
-            "Effect4Amount": "30",
-            "Effect5Amount": "0.15"
+            "Effect4Amount": "20",
+            "Effect5Amount": "0.1"
           },
           "depth": 3
         },
@@ -16520,7 +16614,6 @@
         },
         "3599": {
           "name": "The Black Spear",
-          "group": "TheBlackSpear",
           "description": "<stats></stats><br><active>Active:</active> Offer to bind with an ally for the remainder of the game, becoming Oathsworn Allies. Oathsworn empowers you both while near one another.",
           "colloq": ";spear",
           "plaintext": "Kalista's spear that binds an Oathsworn Ally.",
@@ -16589,7 +16682,6 @@
         },
         "3631": {
           "name": "Siege Ballista",
-          "group": "SiegeSniperCannonGroup",
           "description": "<br><font color='#FF9900'>Deploys a ballista that shoots the closest turret.</font><br><br>Places a long range ballista if within 2200 range of an enemy turret. After an 5 second delay, it will begin firing at the nearest enemy turret, dealing heavy damage. If the targeted turret expires, the ballista will as well.",
           "colloq": "",
           "plaintext": "Place a long range anti-turret ballista",
@@ -16710,7 +16802,6 @@
         },
         "3634": {
           "name": "Tower: Beam of Ruination",
-          "group": "SiegeLaserAffixGroup",
           "description": "<br><font color='#FF9900'>Attach, then recast to fire a damaging beam from a turret to your cursor.</font><br><br><font color='#FF9900'>First Cast:</font> Attach a Slayer Beam to the target turret that can be fired 3 times.<br></br><font color='#FF9900'>Next Three Casts:</font> Fires the attached beam towards your cursor, dealing 30/level + 30% of the hit target's maximum health (20% damage to minions) in magic damage to all targets in a line.<br></br><br></br>Beam will last 15 seconds, or until it has been fired 3 times.",
           "colloq": "",
           "plaintext": "Attaches a three shot beam to a turret which can then be aimed and fired",
@@ -16755,7 +16846,6 @@
         },
         "3635": {
           "name": "Port Pad",
-          "group": "SiegeTeleportPadGroup",
           "description": "<br><font color='#FF9900'>Deploy an additional teleport target.</font><br><br>Places a Port Pad at target location. After a 4 second delay, it activates, allowing you or your allies to teleport to it from base.",
           "colloq": "",
           "plaintext": "Creates another point for your team to Teleport to",
@@ -16796,7 +16886,6 @@
         },
         "3636": {
           "name": "Tower: Storm Bulwark",
-          "group": "SiegeEmergencyShieldGroup",
           "description": "<br><font color='#FF9900'>Makes a turret go invulnerable, then rain fire.</font><br><br>Makes the target turret invulnerable for 6 seconds. Two seconds before expiry, it unleashes a missile volley, dealing 650 true damage over the remaining time to all nearby enemies.<br><br>Cannot be used on the same turret more than once in 15 seconds",
           "colloq": "",
           "plaintext": "Make a turret go invulnerable while charging a powerful barrage",
@@ -16873,7 +16962,6 @@
         },
         "3640": {
           "name": "Flash Zone",
-          "group": "SiegeFlashZoneGroup",
           "description": "<br><font color='#FF9900'>Allows team to cast Flash repeatedly in a limited zone.</font><br><br>Creates a magic zone for your team for 5 seconds. While in this zone, you and your allies have your summoner spells replaced by an instant cast blink that moves you to any location in the zone (1 second cooldown)",
           "colloq": "",
           "plaintext": "Allows you and allies to repeatedly flash while in a zone",
@@ -16912,7 +17000,6 @@
         },
         "3641": {
           "name": "Vanguard Banner",
-          "group": "SiegePortableBarracksGroup",
           "description": "<br><font color='#FF9900'>Place a banner that buffs minions.</font><br><br>Place a Vanguard Banner at target location. After an 2 second delay, any nearby minions will be granted a buff, increasing their damage by 50%, and granting them 50 Armor and 100 Magic Resistance while within range.",
           "colloq": "",
           "plaintext": "Strengthens nearby minions",
@@ -16956,7 +17043,6 @@
         },
         "3642": {
           "name": "Siege Refund",
-          "group": "SiegeRefundGroup",
           "description": "Refunds all purchased Siege Weapons for their full price.",
           "colloq": ";",
           "plaintext": "Refunds all current Siege Weapons",
@@ -16994,7 +17080,6 @@
         },
         "3643": {
           "name": "Entropy Field",
-          "group": "SiegeTimefieldGroup",
           "description": "<br><font color='#FF9900'>Stun minions and slow champions in an area.</font><br><br>Places an Entropy Field at target location for 5 seconds.  Enemy minions and Siege Ballistas trapped in the field are unable to move or attack while in the field.  Enemy champions in the field have their Movement Speed reduced by 25%.",
           "colloq": "",
           "plaintext": "Places a field that stuns enemy minions and slows champions",
@@ -17034,7 +17119,6 @@
         },
         "3645": {
           "name": "Seer Stone (Trinket)",
-          "group": "RelicBase",
           "description": "<groupLimit>Limited to 1 Trinket.</groupLimit><br><br><active>Active:</active> Reveals a small area within <font color='#FFFFF'>1400</font> range for 3 seconds. Enemy champions will be revealed for 5 seconds (60 second cooldown)",
           "colloq": "blue;",
           "plaintext": "Briefly reveals a nearby targeted area",
@@ -17079,7 +17163,6 @@
         },
         "3647": {
           "name": "Shield Totem",
-          "group": "SiegeShieldGeneratorGroup",
           "description": "<br><font color='#FF9900'>Place a totem that shields nearby deployables.</font><br><br>Places a Shield Totem at target location. After a 2 second delay, the totem will activate, granting a 2 (+1 per additional Shield Totem) strength shield to all nearby deployables.",
           "colloq": "",
           "plaintext": "Grants bonus health to nearby Siege Weapons",
@@ -17350,8 +17433,7 @@
         },
         "3706": {
           "name": "Stalker's Blade",
-          "group": "JungleItems",
-          "description": "<groupLimit>Limited to 1 Jungle item</groupLimit><br><br><stats>+10% Life Steal vs. Monsters<br><mana>+180% Base Mana Regen while in Jungle</mana></stats><br><br><unique>UNIQUE Passive - Chilling Smite:</unique> Smite can be cast on enemy champions, dealing reduced true damage and stealing 20% Movement Speed for 2 seconds. <br><unique>UNIQUE Passive - Tooth / Nail:</unique> Basic attacks deal 20 bonus damage vs. monsters. Damaging a monster with a spell or attack steals 30 Health over 5 seconds. Killing monsters grants <font color='#99BBBB'><a href='SpecialJungleExperience'>special bonus experience</a></font>.",
+          "description": "<groupLimit>Limited to 1 Jungle item</groupLimit><br><br><stats>+10% Life Steal vs. Monsters<br><mana>+180% Base Mana Regen while in Jungle</mana></stats><br><br><unique>UNIQUE Passive - Chilling Smite:</unique> Smite can be cast on enemy champions, dealing reduced true damage and stealing 20% Movement Speed for 2 seconds. <br><unique>UNIQUE Passive - Tooth / Nail:</unique> Basic attacks deal 25 bonus damage vs. monsters. Damaging a monster with a spell or attack steals 30 Health over 5 seconds. Killing monsters grants <font color='#99BBBB'><a href='SpecialJungleExperience'>special bonus experience</a></font>.",
           "colloq": ";jungle;Jungle;jangle",
           "plaintext": "Lets your Smite slow Champions",
           "from": [
@@ -17398,7 +17480,7 @@
           "stats": {},
           "effect": {
             "Effect1Amount": "30",
-            "Effect2Amount": "20",
+            "Effect2Amount": "25",
             "Effect3Amount": "1.8",
             "Effect4Amount": "5",
             "Effect5Amount": "30",
@@ -17410,8 +17492,7 @@
         },
         "3711": {
           "name": "Tracker's Knife",
-          "group": "JungleItems",
-          "description": "<groupLimit>Limited to 1 Jungle item</groupLimit><br><br><stats>+10% Life Steal vs. Monsters<br><mana>+180% Base Mana Regen while in Jungle</mana></stats><br><br><unique>UNIQUE Passive - Tooth / Nail:</unique> Basic attacks deal 20 bonus damage vs. monsters. Damaging a monster with a spell or attack steals 30 Health over 5 seconds. Killing monsters grants <font color='#99BBBB'><a href='SpecialJungleExperience'>special bonus experience</a></font>.<br><active>UNIQUE Active - Warding:</active> Consumes a charge to place a <font color='#BBFFFF'>Stealth Ward</font> that reveals the surrounding area for 150 seconds. Holds up to 2 charges which refill upon visiting the shop. <br><br><rules>(A player may only have 3 <font color='#BBFFFF'>Stealth Wards</font> on the map at one time. Unique Passives with the same name don't stack.)</rules>",
+          "description": "<groupLimit>Limited to 1 Jungle item</groupLimit><br><br><stats>+10% Life Steal vs. Monsters<br><mana>+180% Base Mana Regen while in Jungle</mana></stats><br><br><unique>UNIQUE Passive - Tooth / Nail:</unique> Basic attacks deal 25 bonus damage vs. monsters. Damaging a monster with a spell or attack steals 30 Health over 5 seconds. Killing monsters grants <font color='#99BBBB'><a href='SpecialJungleExperience'>special bonus experience</a></font>.<br><active>UNIQUE Active - Warding:</active> Consumes a charge to place a <font color='#BBFFFF'>Stealth Ward</font> that reveals the surrounding area for 150 seconds. Holds up to 2 charges which refill upon visiting the shop. <br><br><rules>(A player may only have 3 <font color='#BBFFFF'>Stealth Wards</font> on the map at one time. Unique Passives with the same name don't stack.)</rules>",
           "colloq": ";jungle;Jungle",
           "plaintext": "Provides Stealth Wards over time",
           "from": [
@@ -17458,7 +17539,7 @@
           "stats": {},
           "effect": {
             "Effect1Amount": "30",
-            "Effect2Amount": "20",
+            "Effect2Amount": "25",
             "Effect3Amount": "1.8",
             "Effect4Amount": "5",
             "Effect5Amount": "30",
@@ -17470,8 +17551,7 @@
         },
         "3715": {
           "name": "Skirmisher's Sabre",
-          "group": "JungleItems",
-          "description": "<groupLimit>Limited to 1 Jungle item</groupLimit><br><br><stats>+10% Life Steal vs. Monsters<br><mana>+180% Base Mana Regen while in Jungle</mana></stats><br><br><passive>Passive - Challenging Smite:</passive> Smite can be cast on enemy champions, marking them for 4 seconds. While marked, basic attacks deal bonus true damage over 3 seconds, you have vision of them, and their damage to you is reduced by 20%.<br><unique>UNIQUE Passive - Tooth / Nail:</unique> Basic attacks deal 20 bonus damage vs. monsters. Damaging a monster with a spell or attack steals 30 Health over 5 seconds. Killing monsters grants <font color='#99BBBB'><a href='SpecialJungleExperience'>special bonus experience</a></font>.",
+          "description": "<groupLimit>Limited to 1 Jungle item</groupLimit><br><br><stats>+10% Life Steal vs. Monsters<br><mana>+180% Base Mana Regen while in Jungle</mana></stats><br><br><passive>Passive - Challenging Smite:</passive> Smite can be cast on enemy champions, marking them for 4 seconds. While marked, basic attacks deal bonus true damage over 3 seconds, you have vision of them, and their damage to you is reduced by 20%.<br><unique>UNIQUE Passive - Tooth / Nail:</unique> Basic attacks deal 25 bonus damage vs. monsters. Damaging a monster with a spell or attack steals 30 Health over 5 seconds. Killing monsters grants <font color='#99BBBB'><a href='SpecialJungleExperience'>special bonus experience</a></font>.",
           "colloq": ";jungle;Jungle",
           "plaintext": "Lets your Smite mark Champions, giving you combat power against them.",
           "from": [
@@ -17516,7 +17596,7 @@
           "stats": {},
           "effect": {
             "Effect1Amount": "30",
-            "Effect2Amount": "20",
+            "Effect2Amount": "25",
             "Effect3Amount": "1.8",
             "Effect4Amount": "5",
             "Effect5Amount": "30",
@@ -17757,9 +17837,10 @@
             "1006"
           ],
           "into": [
-            "3105",
             "3083",
             "3084",
+            "3107",
+            "3109",
             "3800"
           ],
           "image": {
@@ -17900,9 +17981,62 @@
           },
           "depth": 3
         },
+        "3814": {
+          "name": "Edge of Night",
+          "description": "<stats>+60 Attack Damage<br>+35 Magic Resist</stats><br><br><unique>UNIQUE Passive:</unique> +15 <a href='Lethality'>Lethality</a><br><unique>UNIQUE Passive:</unique> +20 Movement Speed out of Combat<br><unique>UNIQUE Active - Night's Veil:</unique> Channel for 1.5 second to grant a spell shield that blocks the next enemy ability. Lasts for 10 seconds (45 second cooldown).<br><br><rules>(Can move while channeling, but taking damage breaks the channel.)</rules>",
+          "colloq": ";lethality",
+          "plaintext": "Blocks an incoming enemy spell.",
+          "stacks": 0,
+          "from": [
+            "1037",
+            "3134",
+            "1033"
+          ],
+          "into": [],
+          "image": {
+            "full": "3814.png",
+            "sprite": "item2.png",
+            "group": "item",
+            "x": 336,
+            "y": 192,
+            "w": 48,
+            "h": 48
+          },
+          "gold": {
+            "base": 675,
+            "purchasable": true,
+            "total": 3100,
+            "sell": 2170
+          },
+          "tags": [
+            "ArmorPenetration",
+            "Damage",
+            "NonbootsMovement",
+            "SpellBlock"
+          ],
+          "maps": {
+            "1": false,
+            "8": true,
+            "10": true,
+            "11": true,
+            "12": true,
+            "14": false
+          },
+          "stats": {
+            "FlatPhysicalDamageMod": 60,
+            "FlatSpellBlockMod": 35
+          },
+          "effect": {
+            "Effect1Amount": "15",
+            "Effect2Amount": "0",
+            "Effect3Amount": "20",
+            "Effect4Amount": "45",
+            "Effect5Amount": "5"
+          },
+          "depth": 3
+        },
         "3901": {
           "name": "Fire at Will",
-          "group": "GangplankRUpgrade01",
           "description": "Requires 500 Silver Serpents.<br><br><unique>UNIQUE Passive:</unique> Cannon Barrage fires at an increasing rate over time (additional 6 waves over the duration).",
           "colloq": "",
           "plaintext": "Cannon Barrage gains extra waves",
@@ -17938,7 +18072,6 @@
         },
         "3902": {
           "name": "Death's Daughter",
-          "group": "GangplankRUpgrade02",
           "description": "Requires 500 Silver Serpents.<br><br><unique>UNIQUE Passive:</unique> Cannon Barrage additionally fires a mega-cannonball at center of the Barrage, dealing 300% true damage and slowing them by 60% for 1.5 seconds. ",
           "colloq": "",
           "plaintext": "Cannon Barrage fires a mega-cannonball",
@@ -17974,7 +18107,6 @@
         },
         "3903": {
           "name": "Raise Morale",
-          "group": "GangplankRUpgrade03",
           "description": "Requires 500 Silver Serpents.<br><br><unique>UNIQUE Passive:</unique> Allies in the Cannon Barrage gain 30% Movement Speed for 2 seconds.",
           "colloq": "",
           "plaintext": "Cannon Barrage hastes allies",
@@ -18290,21 +18422,21 @@
     },
     "headers": {
       "content-type": "application/json",
-      "content-length": "205473",
+      "content-length": "208092",
       "connection": "close",
       "accept-ranges": "bytes",
       "access-control-allow-origin": "*",
       "cache-control": "max-age=315360000, public",
-      "date": "Tue, 18 Oct 2016 03:00:06 GMT",
-      "etag": "\"289f51-322a1-53f07234b1f40\"",
+      "date": "Fri, 04 Nov 2016 03:00:07 GMT",
+      "etag": "\"30bf3f-32cdc-5406e22348200\"",
       "expires": "Thu, 31 Dec 2099 00:00:00 GMT",
-      "last-modified": "Mon, 17 Oct 2016 03:26:13 GMT",
+      "last-modified": "Thu, 03 Nov 2016 23:44:08 GMT",
       "server": "Apache/2.2.29 (Amazon)",
-      "via": "1.1 varnish, 1.1 ba3e50e1cbbe6cb967ec7e40b336dd55.cloudfront.net (CloudFront)",
-      "x-varnish": "2092555399",
-      "age": "1175567",
+      "via": "1.1 varnish, 1.1 3e55621828a782063ebdaf11bf7ed303.cloudfront.net (CloudFront)",
+      "x-varnish": "2423686980",
+      "age": "578079",
       "x-cache": "Hit from cloudfront",
-      "x-amz-cf-id": "icWEhmFTOU0yYYujD68WgXcqm-tnpvMmUNOA2XlGLLKZ5Bk2EpIFAA=="
+      "x-amz-cf-id": "t06Q83Eor4VK45bieIav7RyxOetsDdviZT8B90-Hc3Ns9ZyiRetX5w=="
     }
   }
 ]


### PR DESCRIPTION
Since `nock.disableNetConnect()` was disabled, some tests were retrieving data from ddragon.

All tests have now been updated to be self-sufficient

(proof: add this to `/etc/hosts/` and the test should still run fine:

```
127.0.0.1 ddragon.leagueoflegends.com
127.0.0.1 euw.api.pvp.net
```
)

Without this, tests were failing. I believe this was due to some weird interaction between superagent and nock, loading the same URL over "network" or over "nock" at different times yielded very weird results (maybe reusing an existing connection, thus bypassing nock?)

This proved to be problematic when ddragon API changed, randomly breaking the tests not fully nocked.

Three tests were in this situation. Interestingly, sometimes the errors returned are from other tests -- as if the "errored" test was "consuming" real http data from another test.

I'm assuming there is something wrong in my test abstraction and they are not fully independent despite my best efforts :(